### PR TITLE
Fix Typo

### DIFF
--- a/collection/Unearthed Arcana 2022 - The Cleric and Revised Species.json
+++ b/collection/Unearthed Arcana 2022 - The Cleric and Revised Species.json
@@ -5230,7 +5230,13 @@
 								],
 								[
 									"8",
-									"{@spell Antipathy/Sympathy Enchantment 8 Holy Aura}",
+									"{@spell Antipathy/Sympathy}",
+									"Enchantment",
+									"No"
+								],
+								[
+									"8",
+									"{@spell Holy Aura}",
 									"Abjuration",
 									"No"
 								],


### PR DESCRIPTION
Caused by missing value in original document
![image](https://github.com/user-attachments/assets/e5ec30b6-2d89-43b3-8040-6b8fe6271157)
