### PR TITLE
fix: Address issues raised by homebrew tag checker

### DIFF
--- a/class/Unearthed Arcana - Artificer Revisited.json
+++ b/class/Unearthed Arcana - Artificer Revisited.json
@@ -5,15 +5,15 @@
 				"json": "UAArtificerRevisited",
 				"abbreviation": "UAAR",
 				"full": "Unearthed Arcana: Artificer Revisited",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-Artificer2-2019.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-02-28",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-Artificer2-2019.pdf",
-				"dateReleased": "2019-02-28"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "d2be1fd3b9"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"class": [
 		{

--- a/class/Unearthed Arcana - Artificer.json
+++ b/class/Unearthed Arcana - Artificer.json
@@ -5,15 +5,15 @@
 				"json": "UAArtificer",
 				"abbreviation": "UAA",
 				"full": "Unearthed Arcana: Artificer",
+				"url": "https://media.wizards.com/2016/dnd/downloads/1_UA_Artificer_20170109.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-01-09",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/1_UA_Artificer_20170109.pdf",
-				"dateReleased": "2017-01-09"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "664abb191a"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"class": [
 		{

--- a/class/Unearthed Arcana - Modifying Classes.json
+++ b/class/Unearthed Arcana - Modifying Classes.json
@@ -5,15 +5,15 @@
 				"json": "UAModifyingClasses",
 				"abbreviation": "UAMC",
 				"full": "Unearthed Arcana: Modifying Classes",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA3_ClassDesignVariants.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-04-06",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA3_ClassDesignVariants.pdf",
-				"dateReleased": "2015-04-06"
+				]
 			}
 		],
 		"dependencies": {
@@ -27,6 +27,13 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "e5840bc030"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants",
+			"UALightDarkUnderdark",
+			"UAWaterborneAdventures"
+		]
 	},
 	"class": [
 		{

--- a/class/Unearthed Arcana - Ranger.json
+++ b/class/Unearthed Arcana - Ranger.json
@@ -5,15 +5,15 @@
 				"json": "UARanger",
 				"abbreviation": "UAR",
 				"full": "Unearthed Arcana: Ranger",
+				"url": "https://media.wizards.com/2015/downloads/dnd/DX_0907_UA_RangerOptions.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-09-09",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/DX_0907_UA_RangerOptions.pdf",
-				"dateReleased": "2015-09-09"
+				]
 			}
 		],
 		"edition": "classic",
@@ -137,16 +137,16 @@
 			},
 			"classFeatures": [
 				"Ambuscade|Ranger (Ambuscade)|UARanger|1",
-				"Natural Explorer|Ranger||1",
-				"Fighting Style|Ranger||2",
+				"Natural Explorer|Ranger|PHB|1",
+				"Fighting Style|Ranger|PHB|2",
 				"Skirmisher's Stealth|Ranger (Ambuscade)|UARanger|2",
-				"Primeval Awareness|Ranger||3",
+				"Primeval Awareness|Ranger|PHB|3",
 				{
 					"classFeature": "Spirit Path|Ranger (Ambuscade)|UARanger|3",
 					"gainSubclassFeature": true
 				},
-				"Ability Score Improvement|Ranger||4",
-				"Extra Attack|Ranger||5"
+				"Ability Score Improvement|Ranger|PHB|4",
+				"Extra Attack|Ranger|PHB|5"
 			],
 			"subclassTitle": "Ranger Path"
 		}
@@ -226,7 +226,7 @@
 					"name": "Spirit Companion",
 					"entries": [
 						"All rangers gain a spirit companion and the ability to invoke its magical power. (Your spirit companion grants you one benefit you can call on in this playtest version of the revised ranger, with more benefits gained at higher levels.) You regain your ability to call on your spirit companion in this way when you finish a short or long rest.",
-						"Once per day as a bonus action, you can command your spirit companion to materialize as a living creature, determined by the ranger path you choose. Your spirit companion manifests as an animal for 1 minute or until your {@status concentration} is broken (as if you are {@status concentration||concentrating} on a spell). You can also dismiss it as a bonus action.",
+						"Once per day as a bonus action, you can command your spirit companion to materialize as a living creature, determined by the ranger path you choose. Your spirit companion manifests as an animal for 1 minute or until your {@status concentration} is broken (as if you are {@status concentration|PHB|concentrating} on a spell). You can also dismiss it as a bonus action.",
 						"The manifested creature gains a bonus to attack rolls and saving throws equal to your Wisdom modifier. It uses the hit points in the animal's stat block or half your hit point maximum, whichever is higher.",
 						"The manifested creature takes its turn on your initiative and acts immediately after you. You control its actions, even if you are {@condition unconscious} or otherwise unable to act."
 					]

--- a/class/Unearthed Arcana - Sidekicks.json
+++ b/class/Unearthed Arcana - Sidekicks.json
@@ -5,15 +5,15 @@
 				"json": "UASidekicks",
 				"abbreviation": "UASIK",
 				"full": "Unearthed Arcana: Sidekicks",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_Sidekicks.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-12-17",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_Sidekicks.pdf",
-				"dateReleased": "2018-12-17"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "5657dc49d7"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"class": [
 		{

--- a/class/Unearthed Arcana - The Ranger, Revised.json
+++ b/class/Unearthed Arcana - The Ranger, Revised.json
@@ -5,15 +5,15 @@
 				"json": "UATheRangerRevised",
 				"abbreviation": "UATRR",
 				"full": "Unearthed Arcana: The Ranger, Revised",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UA_RevisedRanger.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-09-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UA_RevisedRanger.pdf",
-				"dateReleased": "2016-09-12"
+				]
 			}
 		],
 		"dependencies": {
@@ -27,6 +27,13 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "cf6005a207"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants",
+			"UALightDarkUnderdark",
+			"UAWaterborneAdventures"
+		]
 	},
 	"class": [
 		{

--- a/class/Unearthed Arcana 2024 - The Artificer.json
+++ b/class/Unearthed Arcana 2024 - The Artificer.json
@@ -6,15 +6,15 @@
 				"json": "XUA2024Artificer",
 				"abbreviation": "XUA24A",
 				"full": "Unearthed Arcana 2024: The Artificer",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/the-artificer/AzQEA72K8EMf9HmU/UA2024-Artificer.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2024-12-17",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/the-artificer/AzQEA72K8EMf9HmU/UA2024-Artificer.pdf",
-				"dateReleased": "2024-12-17"
+				]
 			}
 		],
 		"edition": "one",
@@ -22,6 +22,11 @@
 		"dateAdded": 1734452950,
 		"dateLastModified": 1764502955,
 		"_dateLastModifiedHash": "3c774284fa"
+	},
+	"_test": {
+		"references": [
+			"XUA2025EberronUpdates"
+		]
 	},
 	"class": [
 		{
@@ -1814,7 +1819,7 @@
 			"subclassSource": "XUA2024Artificer",
 			"level": 3,
 			"entries": [
-				"You can customize your Arcane Armor. When you do so, choose one of the following armor models: {@subclassFeature Dreadnaught|Artificer|XUA2024Artificer|Armorer|XUA2024Artificer|3|XUA2024Artificer}, {@subclassFeature Guardian|XUA2024Artificer|Armorer|XUA2024Artificer|3|XUA2024Artificer}, or {@subclassFeature Infiltrator|XUA2024Artificer|Armorer|XUA2024Artificer|3|XUA2024Artificer}. The model you choose gives you special benefits while you wear it.",
+				"You can customize your Arcane Armor. When you do so, choose one of the following armor models: {@subclassFeature Dreadnaught|Artificer|XUA2024Artificer|Armorer|XUA2024Artificer|3|XUA2024Artificer}, {@subclassFeature Guardian|Artificer|XUA2024Artificer|Armorer|XUA2024Artificer|3|XUA2024Artificer}, or {@subclassFeature Infiltrator|Artificer|XUA2024Artificer|Armorer|XUA2024Artificer|3|XUA2024Artificer}. The model you choose gives you special benefits while you wear it.",
 				"Each model includes a special weapon. When you attack with that weapon, you can add your Intelligence modifier, instead of Strength or Dexterity modifier, to the attack and damage rolls.",
 				"You can change the armor's model whenever you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB} if you have {@item Smith's Tools|XPHB} in hand.",
 				{

--- a/class/Unearthed Arcana 2025 - Psion Update.json
+++ b/class/Unearthed Arcana 2025 - Psion Update.json
@@ -6,16 +6,16 @@
 				"json": "XUA2025PsionUpdate",
 				"abbreviation": "XUA25PU",
 				"full": "Unearthed Arcana 2025: Psion Update",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/psion-update/kZh2hf4yC7KS45wW/UA2025-Psion+Update.pdf",
+				"version": "1.1.0",
+				"dateReleased": "2025-10-02",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
-					"Lyra [he/him]",
-					"Giddy"
-				],
-				"version": "1.1.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/psion-update/kZh2hf4yC7KS45wW/UA2025-Psion+Update.pdf",
-				"dateReleased": "2025-10-02"
+					"Giddy",
+					"Lyra [he/him]"
+				]
 			}
 		],
 		"dependencies": {
@@ -37,6 +37,12 @@
 		"dateAdded": 1759589353,
 		"dateLastModified": 1767560915,
 		"_dateLastModifiedHash": "8f3cac1644"
+	},
+	"_test": {
+		"references": [
+			"XUA2025Psion",
+			"XUA2025EberronUpdates"
+		]
 	},
 	"class": [
 		{
@@ -2590,7 +2596,7 @@
 					"items": [
 						"The target regards all creatures it can see as enemies.",
 						"Whenever the target chooses a creature other than itself for an attack, spell, or other ability, it must choose at random from among the creatures it can see within range of that attack, spell, or other ability.",
-						"The target must make an {@action {@action Opportunity Attack|XPHB|Opportunity Attacks}|XPHB} each time it is able to."
+						"The target must make an {@action Opportunity Attack|XPHB} each time it is able to."
 					]
 				},
 				"Each time the target takes damage, it makes another Intelligence saving throw. On a successful save, the spell ends."

--- a/class/Unearthed Arcana 2025 - The Psion.json
+++ b/class/Unearthed Arcana 2025 - The Psion.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025Psion",
 				"abbreviation": "XUA25P",
 				"full": "Unearthed Arcana 2025: The Psion",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/the-psion/mXCPWlh2yy5tBKqP/UA2025-ThePsion.pdf",
+				"version": "1.1.0",
+				"dateReleased": "2025-05-27",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.1.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/the-psion/mXCPWlh2yy5tBKqP/UA2025-ThePsion.pdf",
-				"dateReleased": "2025-05-27"
+				]
 			}
 		],
 		"optionalFeatureTypes": {
@@ -25,6 +25,12 @@
 		"dateAdded": 1748424864,
 		"dateLastModified": 1765470073,
 		"_dateLastModifiedHash": "7aa35d9a7a"
+	},
+	"_test": {
+		"references": [
+			"XUA2025EberronUpdates",
+			"XUA2025PsionUpdate"
+		]
 	},
 	"class": [
 		{

--- a/collection/Unearthed Arcana - Class Feature Variants.json
+++ b/collection/Unearthed Arcana - Class Feature Variants.json
@@ -5,15 +5,15 @@
 				"json": "UAClassFeatureVariants",
 				"abbreviation": "UACFV",
 				"full": "Unearthed Arcana: Class Feature Variants",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-ClassFeatures.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-11-04",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-ClassFeatures.pdf",
-				"dateReleased": "2019-11-04"
+				]
 			}
 		],
 		"edition": "classic",
@@ -1146,15 +1146,15 @@
 				"When you gain the Font of Magic feature, you get access to the following ways to spend your sorcery points.",
 				{
 					"type": "refClassFeature",
-					"classFeature": "Empowering Reserves|Sorcerer|UAClassFeatureVariants|2"
+					"classFeature": "Empowering Reserves|Sorcerer|PHB|2|UAClassFeatureVariants"
 				},
 				{
 					"type": "refClassFeature",
-					"classFeature": "Imbuing Touch|Sorcerer|UAClassFeatureVariants|2"
+					"classFeature": "Imbuing Touch|Sorcerer|PHB|2|UAClassFeatureVariants"
 				},
 				{
 					"type": "refClassFeature",
-					"classFeature": "Sorcerous Fortitude|Sorcerer|UAClassFeatureVariants|2"
+					"classFeature": "Sorcerous Fortitude|PHB|2|Sorcerer|UAClassFeatureVariants"
 				}
 			]
 		},

--- a/collection/Unearthed Arcana - Downtime.json
+++ b/collection/Unearthed Arcana - Downtime.json
@@ -5,15 +5,15 @@
 				"json": "UADowntime",
 				"abbreviation": "UADown",
 				"full": "Unearthed Arcana: Downtime",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA_Downtime.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-04-10",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA_Downtime.pdf",
-				"dateReleased": "2017-04-10"
+				]
 			}
 		],
 		"edition": "classic",
@@ -152,11 +152,23 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"The item is a fake, planted by an enemy."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"The item is stolen by the party's enemies."
 								],
 								[
@@ -164,7 +176,13 @@
 									"The item is cursed by a god."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"The item's original owner will kill to reclaim it; the party's enemies spread news of its sale."
 								],
 								[
@@ -172,7 +190,13 @@
 									"The item is at the center of a dark prophecy."
 								],
 								[
-									"6*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 6
+										},
+										"entry": "6*"
+									},
 									"The seller is murdered before the sale."
 								],
 								[
@@ -184,7 +208,13 @@
 									"The item is the key to freeing an evil entity."
 								],
 								[
-									"9*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 9
+										},
+										"entry": "9*"
+									},
 									"A third party bids on the item, doubling its price."
 								],
 								[
@@ -196,7 +226,13 @@
 									"The item is tied to a cult."
 								],
 								[
-									"12*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 12
+										},
+										"entry": "12*"
+									},
 									"The party's enemies spread rumors that the item is an artifact of evil."
 								]
 							],
@@ -282,11 +318,23 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"A pickpocket lifts {@dice 1d10 × 10} gp from you."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"A bar brawl leaves you with a scar."
 								],
 								[
@@ -294,7 +342,13 @@
 									"You have fuzzy memories of doing something very, very illegal, but can't remember exactly what."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"You are banned from a tavern for obnoxious behavior."
 								],
 								[
@@ -310,7 +364,13 @@
 									"Streaking naked through the streets seemed like a great idea at the time."
 								],
 								[
-									"8*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 8
+										},
+										"entry": "8*"
+									},
 									"Everyone is calling you by some weird, embarrassing nickname, like Puddle Drinker or Bench Slayer, and no one will say why."
 								],
 								[
@@ -339,7 +399,13 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"You accidentally insult a guild master, and only a public apology will let you do business there again."
 								],
 								[
@@ -347,15 +413,33 @@
 									"You swore to complete some quest on behalf of a temple or guild."
 								],
 								[
-									"3*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 3
+										},
+										"entry": "3*"
+									},
 									"A social gaffe has made you the talk of the town."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"A particularly obnoxious person has taken an intense romantic interest in you."
 								],
 								[
-									"5*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 5
+										},
+										"entry": "5*"
+									},
 									"You have made a rival out of a local spellcaster."
 								],
 								[
@@ -388,7 +472,13 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"A pushy noble family wants to marry off one of their scions to you."
 								],
 								[
@@ -400,11 +490,23 @@
 									"You have agreed to take on a noble's debts."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"You have been challenged to a joust by a knight."
 								],
 								[
-									"5*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 5
+										},
+										"entry": "5*"
+									},
 									"You have made a rival out of a local noble."
 								],
 								[
@@ -412,7 +514,13 @@
 									"A boring noble insists you visit each day and listen to long, tedious theories of magic."
 								],
 								[
-									"7*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 7
+										},
+										"entry": "7*"
+									},
 									"You have become the target of a variety of embarrassing rumors."
 								],
 								[
@@ -587,15 +695,33 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"Rumors swirl that what you're working on is unstable and a threat to the entire community."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"You have no idea why everyone thinks your work requires you to make blood sacrifices, but that's what folk are saying."
 								],
 								[
-									"3*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 3
+										},
+										"entry": "3*"
+									},
 									"Your tools are stolen, forcing you to buy new ones."
 								],
 								[
@@ -603,11 +729,23 @@
 									"A local wizard shows keen interest in your work and insists on observing you."
 								],
 								[
-									"5*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 5
+										},
+										"entry": "5*"
+									},
 									"A powerful noble offers a hefty price for your work and is not used to hearing no as an answer."
 								],
 								[
-									"6*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 6
+										},
+										"entry": "6*"
+									},
 									"A dwarf clan accuses you of stealing their secret lore to fuel your work."
 								],
 								[
@@ -615,7 +753,13 @@
 									"A paladin approaches you and claims that the item you are working on is the key to completing a heroic quest."
 								],
 								[
-									"8*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 8
+										},
+										"entry": "8*"
+									},
 									"A rival spreads rumors that your work is shoddy and prone to failure."
 								]
 							],
@@ -749,11 +893,23 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"A bounty equal to your earnings is offered for information about your crime."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"An unknown person contacts you, threatening to reveal your crime if you don't render a service."
 								],
 								[
@@ -761,7 +917,13 @@
 									"Your victim is financially ruined by your crime."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"Someone who knows of your crime has been arrested on an unrelated crime."
 								],
 								[
@@ -781,11 +943,23 @@
 									"Your victim approaches one of your adventuring companions to solve the crime."
 								],
 								[
-									"9*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 9
+										},
+										"entry": "9*"
+									},
 									"A paladin or cleric of justice swears to avenge your robbery."
 								],
 								[
-									"10*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 10
+										},
+										"entry": "10*"
+									},
 									"Your victim has a heart of gold; everyone in town is looking for you, the thieving scumbag."
 								]
 							],
@@ -871,11 +1045,23 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"You are accused of cheating. You decide whether you actually did or were framed."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"The town guard raids the gambling hall and throws you in jail."
 								],
 								[
@@ -883,7 +1069,13 @@
 									"You accrue a debt during the game, one that your opponent insists you pay by taking on a task."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"A noble in town loses badly to you and loudly vows to get revenge."
 								],
 								[
@@ -978,11 +1170,23 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"A rival fighter swears to take revenge on you."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"A crime boss approaches you and offers to pay you to intentionally lose a few matches."
 								],
 								[
@@ -990,11 +1194,23 @@
 									"You defeat a popular local champion, drawing the crowd's ire."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"You defeat a noble's servant, drawing the wrath of the noble's house."
 								],
 								[
-									"5*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 5
+										},
+										"entry": "5*"
+									},
 									"You are accused of cheating. Whether the allegation is true or not, your reputation is tarnished."
 								],
 								[
@@ -1123,7 +1339,13 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"You have offended a priest through your words or actions."
 								],
 								[
@@ -1135,7 +1357,13 @@
 									"A secret sect in the temple offers you membership."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"A rival temple tries to recruit you as a spy."
 								],
 								[
@@ -1238,7 +1466,13 @@
 									"You accidentally damage a rare book."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"You offend a sage, who demands an extravagant gift."
 								],
 								[
@@ -1246,11 +1480,23 @@
 									"If you had known that book was cursed, you never would have opened it."
 								],
 								[
-									"4*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 4
+										},
+										"entry": "4*"
+									},
 									"A sage with strange theories on reality becomes obsessed with convincing you."
 								],
 								[
-									"5*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 5
+										},
+										"entry": "5*"
+									},
 									"Your actions cause you to be banned from a library until you make reparations."
 								],
 								[
@@ -1372,7 +1618,13 @@
 									"You buy up the last of the rare ink used to craft scrolls, angering a wizard in town."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"The priest of a temple of good accuses you of trafficking in dark magic."
 								],
 								[
@@ -1388,7 +1640,13 @@
 									"The rare parchment you bought for your scroll has a barely visible map on it."
 								],
 								[
-									"6*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 6
+										},
+										"entry": "6*"
+									},
 									"A thief attempts to break into your workroom."
 								]
 							],
@@ -1503,15 +1761,33 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"The characters' enemies secretly arrange to buy the item to use it against them."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"The item is stolen."
 								],
 								[
-									"3*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 3
+										},
+										"entry": "3*"
+									},
 									"A rival circulates rumors that the item is a fake."
 								],
 								[
@@ -1523,7 +1799,13 @@
 									"The item's previous owner, or surviving allies, vow to retake it by force."
 								],
 								[
-									"6*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 6
+										},
+										"entry": "6*"
+									},
 									"The buyer is murdered before the sale."
 								],
 								[
@@ -1578,7 +1860,13 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"Your instructor disappears, forcing you to spend a workweek finding a new one"
 								],
 								[
@@ -1586,7 +1874,13 @@
 									"Your teacher instructs you in rare, archaic methods, which draw comment from others."
 								],
 								[
-									"3*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 3
+										},
+										"entry": "3*"
+									},
 									"Your teacher is a spy sent to learn your plans for the near future."
 								],
 								[
@@ -1683,15 +1977,33 @@
 							],
 							"rows": [
 								[
-									"1*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 1
+										},
+										"entry": "1*"
+									},
 									"A difficult customer or a fight with a coworker reduces the lifestyle you earn by one category."
 								],
 								[
-									"2*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 2
+										},
+										"entry": "2*"
+									},
 									"Your employer's financial difficulties result in your not being paid."
 								],
 								[
-									"3*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 3
+										},
+										"entry": "3*"
+									},
 									"A coworker with ties to an important family in town takes a dislike to you."
 								],
 								[
@@ -1699,11 +2011,23 @@
 									"Your employer is involved with a dark cult or a criminal enterprise."
 								],
 								[
-									"5*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 5
+										},
+										"entry": "5*"
+									},
 									"The local crime ring targets your business for a shakedown."
 								],
 								[
-									"6*",
+									{
+										"type": "cell",
+										"roll": {
+											"exact": 6
+										},
+										"entry": "6*"
+									},
 									"You gain a reputation for laziness (unjust or not, your choice), giving you disadvantage on checks made for this downtime activity for 30 days."
 								]
 							],

--- a/collection/Unearthed Arcana - Dragonmarks.json
+++ b/collection/Unearthed Arcana - Dragonmarks.json
@@ -6,15 +6,15 @@
 				"json": "UADragonmarks",
 				"abbreviation": "UADrgM",
 				"full": "Unearthed Arcana: Dragonmarks",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_Dragonmarks.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-09-10",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_Dragonmarks.pdf",
-				"dateReleased": "2018-09-10"
+				]
 			}
 		],
 		"edition": "classic",
@@ -868,7 +868,7 @@
 					"ability": "wis",
 					"innate": {
 						"1": [
-							"bladeward#c"
+							"blade ward#c"
 						]
 					},
 					"known": {
@@ -924,7 +924,7 @@
 			"name": "Elf (Mark of Shadow)",
 			"source": "UADragonmarks",
 			"entries": [
-				"The Mark of Shadows lets an elf weave illusions from shadows, crafting sounds and images to distract or delight. The mark also allows its bearer to draw on the shadows, making it an easy matter to avoid detection or even disappear while in plain sight. It is a valuable tool for an {@background entertainer}, a {@background spy}, or an assassin; each elf who bears it will have to decide which path to follow.",
+				"The Mark of Shadows lets an elf weave illusions from shadows, crafting sounds and images to distract or delight. The mark also allows its bearer to draw on the shadows, making it an easy matter to avoid detection or even disappear while in plain sight. It is a valuable tool for an {@background entertainer}, a {@background Variant Criminal (Spy)|PHB|spy}, or an assassin; each elf who bears it will have to decide which path to follow.",
 				"The Mark of Shadow only manifests on elves. If your character has the Mark of Shadow, this is your elf subrace."
 			]
 		},
@@ -1879,7 +1879,7 @@
 							"name": "The Mark of Shadow",
 							"page": 5,
 							"entries": [
-								"The Mark of Shadows lets an elf weave illusions from shadows, crafting sounds and images to distract or delight. The mark also allows its bearer to draw on the shadows, making it an easy matter to avoid detection or even disappear while in plain sight. It is a valuable tool for an {@background entertainer}, a {@background spy}, or an assassin; each elf who bears it will have to decide which path to follow.",
+								"The Mark of Shadows lets an elf weave illusions from shadows, crafting sounds and images to distract or delight. The mark also allows its bearer to draw on the shadows, making it an easy matter to avoid detection or even disappear while in plain sight. It is a valuable tool for an {@background entertainer}, a {@background Variant Criminal (Spy)|PHB|spy}, or an assassin; each elf who bears it will have to decide which path to follow.",
 								"The Mark of Shadow only manifests on elves. If your character has the Mark of Shadow, this is your elf subrace.",
 								{
 									"type": "statblock",

--- a/collection/Unearthed Arcana - Eberron.json
+++ b/collection/Unearthed Arcana - Eberron.json
@@ -5,21 +5,26 @@
 				"json": "UAEberron",
 				"abbreviation": "UAEB",
 				"full": "Unearthed Arcana: Eberron",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Eberron_v1.1.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-02-02",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Eberron_v1.1.pdf",
-				"dateReleased": "2015-02-02"
+				]
 			}
 		],
 		"edition": "classic",
 		"dateAdded": 1701616429,
 		"dateLastModified": 1759315511,
 		"_dateLastModifiedHash": "084ea8311b"
+	},
+	"_test": {
+		"references": [
+			"UARacesOfEberron"
+		]
 	},
 	"subclass": [
 		{

--- a/collection/Unearthed Arcana - Encounter Building.json
+++ b/collection/Unearthed Arcana - Encounter Building.json
@@ -5,15 +5,15 @@
 				"json": "UAEncounterBuilding",
 				"abbreviation": "UAEB",
 				"full": "Unearthed Arcana: Encounter Building",
+				"url": "https://media.wizards.com/2016/dnd/downloads/Encounter_Building.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-10-10",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/Encounter_Building.pdf",
-				"dateReleased": "2016-10-10"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Fiendish Options.json
+++ b/collection/Unearthed Arcana - Fiendish Options.json
@@ -5,15 +5,15 @@
 				"json": "UAFiendishOptions",
 				"abbreviation": "UAFO",
 				"full": "Unearthed Arcana: Fiendish Options",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA_FiendishOptions.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-10-09",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA_FiendishOptions.pdf",
-				"dateReleased": "2017-10-09"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Gothic Heroes.json
+++ b/collection/Unearthed Arcana - Gothic Heroes.json
@@ -5,15 +5,15 @@
 				"json": "UAGothicHeroes",
 				"abbreviation": "UAGH",
 				"full": "Unearthed Arcana: Gothic Heroes",
+				"url": "https://media.dnd.wizards.com/upload/articles/UA%20Gothic%20Characters.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-04-04",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dnd.wizards.com/upload/articles/UA%20Gothic%20Characters.pdf",
-				"dateReleased": "2016-04-04"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Into the Wild.json
+++ b/collection/Unearthed Arcana - Into the Wild.json
@@ -5,15 +5,15 @@
 				"json": "UAIntoTheWild",
 				"abbreviation": "UAItW",
 				"full": "Unearthed Arcana: Into The Wild",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_IntoTheWild.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-02-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_IntoTheWild.pdf",
-				"dateReleased": "2018-02-12"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Modern Magic.json
+++ b/collection/Unearthed Arcana - Modern Magic.json
@@ -5,15 +5,15 @@
 				"json": "UAModernMagic",
 				"abbreviation": "UAMM",
 				"full": "Unearthed Arcana: Modern Magic",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA_ModernMagic.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-08-03",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA_ModernMagic.pdf",
-				"dateReleased": "2015-08-03"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1735770386,
 		"_dateLastModifiedHash": "bec5001844"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"subclass": [
 		{
@@ -207,7 +212,7 @@
 			"level": 1,
 			"header": 1,
 			"entries": [
-				"When you choose this domain at 1st level, you gain the {@spell On/Off (UA)|UAModernMagic|on/off} cantrip in addition to your chosen cantrips."
+				"When you choose this domain at 1st level, you gain the {@spell on/off|UAModernMagic} cantrip in addition to your chosen cantrips."
 			]
 		},
 		{
@@ -314,7 +319,7 @@
 					"type": "entries",
 					"name": "Expanded Spell List",
 					"entries": [
-						"The Ghost in the Machine lets you choose from an expanded list of spells when you learn a warlock spell. You gain the on/off cantrip, and the following new spells are added to the warlock spell list for you.",
+						"The Ghost in the Machine lets you choose from an expanded list of spells when you learn a warlock spell. You gain the {@spell on/off|UAModernMagic} cantrip, and the following new spells are added to the warlock spell list for you.",
 						"Spells marked with an asterisk can be found in Unearthed Arcana: Modern Magic.",
 						{
 							"type": "table",
@@ -1126,7 +1131,7 @@
 			]
 		},
 		{
-			"name": "On/Off (UA)",
+			"name": "On/Off",
 			"source": "UAModernMagic",
 			"page": 7,
 			"level": 0,

--- a/collection/Unearthed Arcana - Prestige Classes and Rune Magic.json
+++ b/collection/Unearthed Arcana - Prestige Classes and Rune Magic.json
@@ -5,15 +5,15 @@
 				"json": "UAPrestigeClassesRunMagic",
 				"abbreviation": "UAPCRM",
 				"full": "Unearthed Arcana: Prestige Classes and Rune Magic",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Rune_Magic_Prestige_Class.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-10-05",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Rune_Magic_Prestige_Class.pdf",
-				"dateReleased": "2015-10-05"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Quick Characters.json
+++ b/collection/Unearthed Arcana - Quick Characters.json
@@ -5,15 +5,15 @@
 				"json": "UAQuickCharacters",
 				"abbreviation": "UAQCh",
 				"full": "Unearthed Arcana: Quick Characters",
+				"url": "https://media.wizards.com/2016/downloads/DND/UA_Quick_PCs_SFG.PDF",
+				"version": "1.0.0",
+				"dateReleased": "2016-07-25",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/downloads/DND/UA_Quick_PCs_SFG.PDF",
-				"dateReleased": "2016-07-25"
+				]
 			}
 		],
 		"edition": "classic",
@@ -881,7 +881,7 @@
 											"{@race Elf (wood)||Wood Elf}"
 										],
 										[
-											"9",
+											"5",
 											"{@race halfling (lightfoot)||Lightfoot Halfling}"
 										],
 										[

--- a/collection/Unearthed Arcana - That Old Black Magic.json
+++ b/collection/Unearthed Arcana - That Old Black Magic.json
@@ -5,15 +5,15 @@
 				"json": "UAThatOldBlackMagic",
 				"abbreviation": "UAOBM",
 				"full": "Unearthed Arcana: That Old Black Magic",
+				"url": "https://media.wizards.com/2015/downloads/dnd/07_UA_That_Old_Black_Magic.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-12-07",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/07_UA_That_Old_Black_Magic.pdf",
-				"dateReleased": "2015-12-07"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Traps Revisited.json
+++ b/collection/Unearthed Arcana - Traps Revisited.json
@@ -5,15 +5,15 @@
 				"json": "UATrapsRevisited",
 				"abbreviation": "UATpR",
 				"full": "Unearthed Arcana: Traps Revisited",
+				"url": "https://media.wizards.com/2017/dnd/downloads/0227_UATraps.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-02-27",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/0227_UATraps.pdf",
-				"dateReleased": "2017-02-27"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - Waterborne Adventures.json
+++ b/collection/Unearthed Arcana - Waterborne Adventures.json
@@ -6,16 +6,16 @@
 				"json": "UAWaterborneAdventures",
 				"abbreviation": "UAWA",
 				"full": "Unearthed Arcana: Waterborne Adventures",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Waterborne_v3.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-05-04",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy",
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Waterborne_v3.pdf",
-				"dateReleased": "2015-05-04"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana - When Armies Clash.json
+++ b/collection/Unearthed Arcana - When Armies Clash.json
@@ -5,15 +5,15 @@
 				"json": "UAWhenArmiesClash",
 				"abbreviation": "UAWAC",
 				"full": "Unearthed Arcana: When Armies Clash",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Battlesystem.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-02-02",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA_Battlesystem.pdf",
-				"dateReleased": "2015-02-02"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana 2020 - Psionic Options Revisited.json
+++ b/collection/Unearthed Arcana 2020 - Psionic Options Revisited.json
@@ -5,15 +5,15 @@
 				"json": "UA2020PsionicOptionsRevisited",
 				"abbreviation": "UA20POR",
 				"full": "Unearthed Arcana: 2020 Psionic Options Revisited",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_PsionicOptions.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-04-14",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_PsionicOptions.pdf",
-				"dateReleased": "2020-04-14"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana 2020 - Spells and Magic Tattoos.json
+++ b/collection/Unearthed Arcana 2020 - Spells and Magic Tattoos.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SpellsAndMagicTattoos",
 				"abbreviation": "UA20SMT",
 				"full": "Unearthed Arcana: 2020 Spells and Magic Tattoos",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020-SpellsTattoos.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-03-26",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020-SpellsTattoos.pdf",
-				"dateReleased": "2020-03-26"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana 2021 - Draconic Options.json
+++ b/collection/Unearthed Arcana 2021 - Draconic Options.json
@@ -5,15 +5,15 @@
 				"json": "UA2021DraconicOptions",
 				"abbreviation": "UA21DO",
 				"full": "Unearthed Arcana: 2021 Draconic Options",
+				"url": "https://media.wizards.com/2021/downloads/Unearthed-Arcana-2021-Draconic-Options.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2021-04-14",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2021/downloads/Unearthed-Arcana-2021-Draconic-Options.pdf",
-				"dateReleased": "2021-04-14"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana 2022 - Character Origins.json
+++ b/collection/Unearthed Arcana 2022 - Character Origins.json
@@ -5,15 +5,15 @@
 				"json": "XUA2022CharacterOptions",
 				"abbreviation": "XUA22CO",
 				"full": "Unearthed Arcana 2022: Character Origins",
+				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/character-origins/CSWCVV0M4B6vX6E1/UA2022-CharacterOrigins.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-08-18",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/character-origins/CSWCVV0M4B6vX6E1/UA2022-CharacterOrigins.pdf",
-				"dateReleased": "2022-08-18"
+				]
 			}
 		],
 		"dependencies": {

--- a/collection/Unearthed Arcana 2022 - Expert Classes.json
+++ b/collection/Unearthed Arcana 2022 - Expert Classes.json
@@ -5,15 +5,15 @@
 				"json": "XUA2022ExpertClasses",
 				"abbreviation": "XUA22EC",
 				"full": "Unearthed Arcana 2022: Expert Classes",
+				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/expert-classes/kpx0MvyfBGHe0XKk/UA2022-Expert-Classes.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-09-29",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/expert-classes/kpx0MvyfBGHe0XKk/UA2022-Expert-Classes.pdf",
-				"dateReleased": "2022-09-29"
+				]
 			}
 		],
 		"dependencies": {
@@ -1723,7 +1723,7 @@
 						],
 						[
 							"4th",
-							"{@spell Lesser Restoration|XUA2022ExpertClasses}"
+							"{@spell Lesser Restoration}"
 						],
 						[
 							"6th",
@@ -1731,11 +1731,11 @@
 						],
 						[
 							"8th",
-							"{@spell Freedom of Movement|XUA2022ExpertClasses}"
+							"{@spell Freedom of Movement}"
 						],
 						[
 							"10th",
-							"{@spell Greater Restoration|XUA2022ExpertClasses}"
+							"{@spell Greater Restoration}"
 						]
 					]
 				}
@@ -2152,7 +2152,7 @@
 			"classSource": "XUA2022ExpertClasses",
 			"level": 15,
 			"entries": [
-				"Your connection to the forces of nature grants you {@feat Blindsight|XUA2022ExpertClasses} with a range of 30 feet."
+				"Your connection to the forces of nature grants you {@variantrule Blindsight|XUA2022ExpertClasses} with a range of 30 feet."
 			]
 		},
 		{
@@ -2664,7 +2664,7 @@
 							"type": "item",
 							"name": "Search",
 							"entries": [
-								"Take the {@action Search Action|XUA2022ExpertClasses|Search Action}."
+								"Take the {@action Search|XUA2022ExpertClasses|Search Action}."
 							]
 						},
 						{
@@ -3021,12 +3021,12 @@
 						{
 							"type": "item",
 							"name": "Firing in Melee",
-							"entry": "Being within 5 feet of an enemy doesn't impose Disadvantage on your {@variantrule Attack Rolls|XUA2022ExpertClasses} with crossbows."
+							"entry": "Being within 5 feet of an enemy doesn't impose Disadvantage on your {@variantrule Attack Roll|XUA2022ExpertClasses|Attack Rolls} with crossbows."
 						},
 						{
 							"type": "item",
 							"name": "Dual Wielding",
-							"entry": "When you make the extra attack of the {@variantrule Light|XUA2022ExpertClasses} weapon property, you can add your Ability Modifier to the damage of the extra attack if that attack is with a crossbow that has the {@variantrule Light|XUA2022ExpertClasses} property."
+							"entry": "When you make the extra attack of the {@itemProperty XUA2022ExpertClasses-L|XUA2022ExpertClasses|Light} weapon property, you can add your Ability Modifier to the damage of the extra attack if that attack is with a crossbow that has the {@itemProperty XUA2022ExpertClasses-L|XUA2022ExpertClasses|Light} property."
 						}
 					]
 				}
@@ -3323,7 +3323,7 @@
 			],
 			"repeatable": false,
 			"entries": [
-				"Immediately after you roll a {@dice d20} for a {@variantrule d20 Test|XUA2022ExpertClasses}, you can roll a {@dice d10} and add the number rolled to the test. Once you use this benefit, you can't use it again until you roll Initiative or finish a Short Rest or a {@variantrule Long Rest|XUA2022ExpertClasses}."
+				"Immediately after you roll a {@dice d20} for a {@variantrule D20 Tests|XUA2022ExpertClasses|d20 Test}, you can roll a {@dice d10} and add the number rolled to the test. Once you use this benefit, you can't use it again until you roll Initiative or finish a Short Rest or a {@variantrule Long Rest|XUA2022ExpertClasses}."
 			]
 		},
 		{
@@ -3565,7 +3565,7 @@
 			],
 			"repeatable": false,
 			"entries": [
-				"When you make the extra attack of the {@variantrule Light|XUA2022ExpertClasses} weapon property, you can add your Ability Modifier to the damage of the extra attack."
+				"When you make the extra attack of the {@itemProperty XUA2022ExpertClasses-L|XUA2022ExpertClasses|Light} weapon property, you can add your Ability Modifier to the damage of the extra attack."
 			]
 		},
 		{
@@ -3609,7 +3609,7 @@
 						{
 							"type": "item",
 							"name": "Fast Wrestler",
-							"entry": "You aren't {@variantrule Slowed|XUA2022ExpertClasses} when you move a creature {@condition Grappled|XUA2022ExpertClasses} by you, provided the creature is your Size or smaller."
+							"entry": "You aren't {@condition Slowed|XUA2022ExpertClasses} when you move a creature {@condition Grappled|XUA2022ExpertClasses} by you, provided the creature is your Size or smaller."
 						},
 						{
 							"type": "item",
@@ -5311,7 +5311,7 @@
 			"weaponCategory": "simple",
 			"property": [
 				"F",
-				"XUA2022ClericAndRevisedSpecies-L"
+				"XUA2022ExpertClasses-L"
 			],
 			"dmg1": "1d6",
 			"dmgType": "P",
@@ -5321,7 +5321,7 @@
 	],
 	"itemProperty": [
 		{
-			"abbreviation": "XUA2022ClericAndRevisedSpecies-L",
+			"abbreviation": "XUA2022ExpertClasses-L",
 			"source": "XUA2022ExpertClasses",
 			"page": 21,
 			"entries": [

--- a/collection/Unearthed Arcana 2022 - Giant Options.json
+++ b/collection/Unearthed Arcana 2022 - Giant Options.json
@@ -5,15 +5,15 @@
 				"json": "UA2022GiantOptions",
 				"abbreviation": "UA22GO",
 				"full": "Unearthed Arcana: 2022 Giant Options",
+				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022-drjwf73f8n.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-05-26",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022-drjwf73f8n.pdf",
-				"dateReleased": "2022-05-26"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana 2022 - Heroes of Krynn Revisited.json
+++ b/collection/Unearthed Arcana 2022 - Heroes of Krynn Revisited.json
@@ -5,15 +5,15 @@
 				"json": "UA2022HeroesOfKrynnRevisited",
 				"abbreviation": "UA22HoKR",
 				"full": "Unearthed Arcana: 2022 Heroes of Krynn Revisited",
+				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022-HeroesofKrynnRevisited.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-04-25",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022-HeroesofKrynnRevisited.pdf",
-				"dateReleased": "2022-04-25"
+				]
 			}
 		],
 		"edition": "classic",

--- a/collection/Unearthed Arcana 2022 - Heroes of Krynn.json
+++ b/collection/Unearthed Arcana 2022 - Heroes of Krynn.json
@@ -5,21 +5,26 @@
 				"json": "UA2022HeroesOfKrynn",
 				"abbreviation": "UA22HoK",
 				"full": "Unearthed Arcana: 2022 Heroes of Krynn",
+				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022HeroesofKrynn.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-03-08",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022HeroesofKrynn.pdf",
-				"dateReleased": "2022-03-08"
+				]
 			}
 		],
 		"edition": "classic",
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "42028c92b2"
+	},
+	"_test": {
+		"references": [
+			"UA2022HeroesOfKrynnRevisited"
+		]
 	},
 	"subclass": [
 		{

--- a/collection/Unearthed Arcana 2022 - The Cleric and Revised Species.json
+++ b/collection/Unearthed Arcana 2022 - The Cleric and Revised Species.json
@@ -5,15 +5,15 @@
 				"json": "XUA2022ClericAndRevisedSpecies",
 				"abbreviation": "XUA22CRS",
 				"full": "Unearthed Arcana 2022: The Cleric and Revised Species",
+				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/cleric-and-revised-species/tr8jAj5cc33uQixi/UA-2022-ClericandSpecies.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-12-01",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/cleric-and-revised-species/tr8jAj5cc33uQixi/UA-2022-ClericandSpecies.pdf",
-				"dateReleased": "2022-12-01"
+				]
 			}
 		],
 		"dependencies": {
@@ -2315,7 +2315,7 @@
 				"silent image",
 				"sleep",
 				"tasha's hideous laughter",
-				"tenser 's floating disk",
+				"tenser's floating disk",
 				"thunderwave",
 				"unseen servant",
 				"witch bolt",
@@ -2346,7 +2346,7 @@
 				"mirror image",
 				"misty step",
 				"phantasmal force",
-				"ray of enfeeblemen t",
+				"ray of enfeeblement",
 				"rope trick",
 				"scorching ray",
 				"see invisibility",
@@ -3003,7 +3003,7 @@
 			"page": 19,
 			"entries": [
 				"Expertise is a special feature that enhances your use of a particular Skill Proficiency. If you gain Expertise, you gain it in one Skill in which you have Proficiency. You can never have Expertise in the same Skill Proficiency more than once.",
-				"When you make an {@variantrule {@variantrule Ability Check|XUA2022ClericAndRevisedSpecies}|XUA2022ClericAndRevisedSpecies} with a Skill Proficiency in which you have Expertise, your Proficiency Bonus is doubled for that check."
+				"When you make an {@variantrule Ability Check|XUA2022ClericAndRevisedSpecies} with a Skill Proficiency in which you have Expertise, your Proficiency Bonus is doubled for that check."
 			]
 		},
 		{
@@ -3529,7 +3529,7 @@
 								],
 								[
 									"1",
-									"{@spell Tenser 's Floating Disk}",
+									"{@spell Tenser's Floating Disk}",
 									"Conjuration",
 									"Yes"
 								],
@@ -3715,7 +3715,7 @@
 								],
 								[
 									"2",
-									"{@spell Ray of Enfeeblemen t}",
+									"{@spell Ray of Enfeeblement}",
 									"Necromancy",
 									"No"
 								],

--- a/collection/Unearthed Arcana 2022 - Wonders of the Multiverse.json
+++ b/collection/Unearthed Arcana 2022 - Wonders of the Multiverse.json
@@ -5,15 +5,15 @@
 				"json": "UA2022WondersOfTheMultiverse",
 				"abbreviation": "UA22WotM",
 				"full": "Unearthed Arcana: 2022 Wonders of the Multiverse",
+				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022-WondersoftheMultiverse.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2022-07-18",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2022/dnd/downloads/UA2022-WondersoftheMultiverse.pdf",
-				"dateReleased": "2022-07-18"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "ecfccfaf9b"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"subclass": [
 		{

--- a/collection/Unearthed Arcana 2023 - Bastions and Cantrips.json
+++ b/collection/Unearthed Arcana 2023 - Bastions and Cantrips.json
@@ -5,15 +5,15 @@
 				"json": "XUA2023BastionsAndCantrips",
 				"abbreviation": "XUA23BC",
 				"full": "Unearthed Arcana 2023: Bastions and Cantrips",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/bastions-cantrips/BRF3GSu0nTfNu8p4/UA2023-BastionsCantrips.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2023-10-05",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/bastions-cantrips/BRF3GSu0nTfNu8p4/UA2023-BastionsCantrips.pdf",
-				"dateReleased": "2023-10-05"
+				]
 			}
 		],
 		"optionalFeatureTypes": {
@@ -23,6 +23,11 @@
 		"dateAdded": 1696529407,
 		"dateLastModified": 1733837795,
 		"_dateLastModifiedHash": "57e2831a84"
+	},
+	"_test": {
+		"references": [
+			"XUA2023PlayersHandbookP7"
+		]
 	},
 	"optionalfeature": [
 		{

--- a/collection/Unearthed Arcana 2023 - Druid & Paladin.json
+++ b/collection/Unearthed Arcana 2023 - Druid & Paladin.json
@@ -5,15 +5,15 @@
 				"json": "XUA2023DruidAndPaladin",
 				"abbreviation": "XUA23DP",
 				"full": "Unearthed Arcana 2023: Player's Handbook: Druid & Paladin",
+				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/druid-paladin/PXoa3UgywnZbwc9U/UA-2023-DruidandPaladin.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2023-02-23",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/druid-paladin/PXoa3UgywnZbwc9U/UA-2023-DruidandPaladin.pdf",
-				"dateReleased": "2023-02-23"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,12 @@
 		"dateAdded": 1663844222,
 		"dateLastModified": 1732568539,
 		"_dateLastModifiedHash": "ee4026cae4"
+	},
+	"_test": {
+		"references": [
+			"XUA2022ClericAndRevisedSpecies",
+			"XUA2022ExpertClasses"
+		]
 	},
 	"class": [
 		{
@@ -3900,7 +3906,7 @@
 								],
 								[
 									"1",
-									"{@spell Commpelled Duel}",
+									"{@spell Compelled Duel}",
 									"Enchantment",
 									"No"
 								],
@@ -5761,7 +5767,7 @@
 			],
 			"entries": [
 				"With the Hide Action, you try to conceal yourself. To do so, you must make a {@dc 15} Dexterity Check ({@skill Stealth}) while you're Heavily Obscured or behind Three-Quarters Cover or Total Cover, and you must be out of any visible enemy's line of sight; if you can see a creature, you can discern whether it can see you.",
-				"On a successful check, you are {@condition Hidden|XUA2023DruidAndPaladin}. Make note of your check's total, which becomes the DC for a creature to find you with a Wisdom Check ({@skill Perception}).",
+				"On a successful check, you are Hidden. Make note of your check's total, which becomes the DC for a creature to find you with a Wisdom Check ({@skill Perception}).",
 				"The condition ends on you immediately after any of the following occurrences: you make a sound louder than a whisper, an enemy finds you, you make an attack roll, or you cast a spell with a verbal component."
 			]
 		},

--- a/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 5.json
+++ b/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 5.json
@@ -5,21 +5,27 @@
 				"json": "XUA2023PlayersHandbookP5",
 				"abbreviation": "XUA23P5",
 				"full": "Unearthed Arcana 2023: Player's Handbook Playtest 5",
+				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/ph-playtest5/owThVp1CESZ1c91y/UA-2023-PH-Playtest5.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2023-04-26",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/one-dnd/ph-playtest5/owThVp1CESZ1c91y/UA-2023-PH-Playtest5.pdf",
-				"dateReleased": "2023-04-26"
+				]
 			}
 		],
 		"edition": "classic",
 		"dateAdded": 1663844222,
 		"dateLastModified": 1745663149,
 		"_dateLastModifiedHash": "4e88b49b0d"
+	},
+	"_test": {
+		"references": [
+			"XUA2022ClericAndRevisedSpecies",
+			"XUA2023DruidAndPaladin"
+		]
 	},
 	"class": [
 		{
@@ -348,7 +354,7 @@
 					"{@item Quiver|phb}",
 					"{@item Dungeoneer's Pack|phb}",
 					"11 GP",
-					"(a) {@item Greatsword} or (b) {@item Longsword}, {@item Shield|phb} and 25 GP"
+					"(a) {@item Greatsword|XUA2023PlayersHandbookP5} or (b) {@item Longsword|XUA2023PlayersHandbookP5}, {@item Shield|phb} and 25 GP"
 				],
 				"goldAlternative": "175 GP"
 			},
@@ -1612,7 +1618,7 @@
 					"{@item Arcane Focus|phb} (Quarterstaff)",
 					"{@item Scholar's Pack|phb}",
 					"{@item Dagger|phb} (2)",
-					"{@item Robe|phb}",
+					"{@item Robes|phb|Robe}",
 					"5 GP"
 				],
 				"goldAlternative": "55"
@@ -5002,7 +5008,7 @@
 				}
 			],
 			"entries": [
-				"You have {@variantrule Truesight|XUA2023PlayersHandbookP5} with a range of 30 feet."
+				"You have {@sense Truesight|XUA2023PlayersHandbookP5} with a range of 30 feet."
 			]
 		}
 	],
@@ -6327,7 +6333,7 @@
 				"silent image",
 				"sleep",
 				"tasha's hideous laughter",
-				"tenser 's floating disk",
+				"tenser's floating disk",
 				"thunderwave",
 				"unseen servant",
 				"witch bolt",
@@ -6358,7 +6364,7 @@
 				"mirror image",
 				"misty step",
 				"phantasmal force",
-				"ray of enfeeblemen t",
+				"ray of enfeeblement",
 				"rope trick",
 				"scorching ray",
 				"see invisibility",
@@ -7841,7 +7847,7 @@
 									"type": "item",
 									"name": "Exhaustion Reduced",
 									"entries": [
-										"If you are exhausted, your level of exhaustion decreases by 1."
+										"If you are {@condition exhausted|XUA2023DruidAndPaladin}, your level of exhaustion decreases by 1."
 									]
 								},
 								{
@@ -7932,7 +7938,7 @@
 					"items": [
 						"{@variantrule Armor Training|XUA2023PlayersHandbookP5}",
 						"{@action Attack|XUA2023PlayersHandbookP5}",
-						"{@variantrule Blindsight|XUA2023PlayersHandbookP5}",
+						"{@sense Blindsight|XUA2023PlayersHandbookP5}",
 						"{@variantrule Climb Speed|XUA2023PlayersHandbookP5}",
 						"{@variantrule Creature Type|XUA2023PlayersHandbookP5}",
 						"{@variantrule D20 Tests|XUA2023PlayersHandbookP5}",
@@ -7960,8 +7966,8 @@
 						"{@variantrule Telepathy|XUA2023PlayersHandbookP5}",
 						"{@variantrule Teleportation|XUA2023PlayersHandbookP5}",
 						"{@variantrule Tool Proficiency|XUA2023PlayersHandbookP5}",
-						"{@variantrule Tremorsense|XUA2023PlayersHandbookP5}",
-						"{@variantrule Truesight|XUA2023PlayersHandbookP5}",
+						"{@sense Tremorsense|XUA2023PlayersHandbookP5}",
+						"{@sense Truesight|XUA2023PlayersHandbookP5}",
 						"{@variantrule Unarmed Strike|XUA2023PlayersHandbookP5}",
 						"{@condition Unconscious|XUA2023PlayersHandbookP5}"
 					]
@@ -8324,7 +8330,7 @@
 								],
 								[
 									"1",
-									"{@spell Tenser 's Floating Disk}",
+									"{@spell Tenser's Floating Disk}",
 									"Conjuration",
 									"Yes"
 								],
@@ -9990,7 +9996,7 @@
 							"type": "item",
 							"name": "Attacks Affected",
 							"entries": [
-								"{@action Attack|XUA2023PlayersHandbookP5} rolls against you have Disadvantage, and your attack rolls have Advantage. If a creature can somehow see you, as with magic or {@variantrule Blindsight|XUA2023PlayersHandbookP5}, you don't gain this benefit against that creature."
+								"{@action Attack|XUA2023PlayersHandbookP5} rolls against you have Disadvantage, and your attack rolls have Advantage. If a creature can somehow see you, as with magic or {@sense Blindsight|XUA2023PlayersHandbookP5}, you don't gain this benefit against that creature."
 							]
 						}
 					]
@@ -10123,7 +10129,7 @@
 			],
 			"entries": [
 				"With the Hide Action, you try to conceal yourself. To do so, you must make a {@dc 15} Dexterity Check ({@skill Stealth}) while you're Heavily Obscured or behind Three-Quarters Cover or Total Cover, and you must be out of any visible enemy's line of sight; if you can see a creature, you can discern whether it can see you.",
-				"On a successful check, you are {@condition Hidden|XUA2023PlayersHandbookP5}. Make note of your check's total, which becomes the DC for a creature to find you with a Wisdom Check ({@skill Perception}).",
+				"On a successful check, you are Hidden. Make note of your check's total, which becomes the DC for a creature to find you with a Wisdom Check ({@skill Perception}).",
 				"The condition ends on you immediately after any of the following occurrences: you make a sound louder than a whisper, an enemy finds you, you make an attack roll, or you cast a spell with a verbal component."
 			]
 		},

--- a/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 6.json
+++ b/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 6.json
@@ -5,21 +5,27 @@
 				"json": "XUA2023PlayersHandbookP6",
 				"abbreviation": "XUA23P6",
 				"full": "Unearthed Arcana 2023: Player's Handbook Playtest 6",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/ph-playtest6/OJVW7QLuHjEFCCVs/UA-2023-PH-Playtest6.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2023-06-28",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/ph-playtest6/OJVW7QLuHjEFCCVs/UA-2023-PH-Playtest6.pdf",
-				"dateReleased": "2023-06-28"
+				]
 			}
 		],
 		"edition": "classic",
 		"dateAdded": 1691158917,
 		"dateLastModified": 1745663149,
 		"_dateLastModifiedHash": "1ef7ea9923"
+	},
+	"_test": {
+		"references": [
+			"XUA2022ClericAndRevisedSpecies",
+			"XUA2023DruidAndPaladin"
+		]
 	},
 	"class": [
 		{
@@ -103,7 +109,7 @@
 					"simple"
 				],
 				"tools": [
-					"three {@variantrule musical instrument|XUA2023PlayersHandbookP6|musical instruments} of your choice"
+					"three {@item musical instrument|PHB|musical instruments} of your choice"
 				],
 				"toolProficiencies": [
 					{
@@ -3706,10 +3712,10 @@
 				}
 			],
 			"subclassFeatures": [
-				"Arcane Trickster|Rogue|XUA2023PlayersHandbookP6|Trickster|XUA2023PlayersHandbookP6|3",
-				"Magical Ambush|Rogue|XUA2023PlayersHandbookP6|Trickster|XUA2023PlayersHandbookP6|9",
-				"Versatile Trickster|Rogue|XUA2023PlayersHandbookP6|Trickster|XUA2023PlayersHandbookP6|13",
-				"Spell Thief|Rogue|XUA2023PlayersHandbookP6|Trickster|XUA2023PlayersHandbookP6|17"
+				"Arcane Trickster|Rogue|XUA2023PlayersHandbookP6|Arcane Trickster|XUA2023PlayersHandbookP6|3",
+				"Magical Ambush|Rogue|XUA2023PlayersHandbookP6|Arcane Trickster|XUA2023PlayersHandbookP6|9",
+				"Versatile Trickster|Rogue|XUA2023PlayersHandbookP6|Arcane Trickster|XUA2023PlayersHandbookP6|13",
+				"Spell Thief|Rogue|XUA2023PlayersHandbookP6|Arcane Trickster|XUA2023PlayersHandbookP6|17"
 			]
 		},
 		{
@@ -4126,7 +4132,7 @@
 							"protection from energy"
 						],
 						"13": [
-							"banishment",
+							"banishment|XUA2022ClericAndRevisedSpecies",
 							"dimension door"
 						],
 						"17": [
@@ -4507,7 +4513,7 @@
 			"classSource": "XUA2023PlayersHandbookP6",
 			"level": 10,
 			"entries": [
-				"You have collected magical knowledge from a wide spectrum of disciplines. As a result, your Bard Spell list now includes the {@variantrule Arcane Spells|XUA2023PlayersHandbookP6|Arcane}, {@variantrule Divine Spells|XUA2023PlayersHandbookP6|Divine}, or {@variantrule Primal Spells|XUA2023PlayersHandbookP6|Primal}."
+				"You have collected magical knowledge from a wide spectrum of disciplines. As a result, your Bard Spell list now includes the {@variantrule Spell Lists|XUA2023PlayersHandbookP6|Arcane, Divine, and Primal spell lists}."
 			]
 		},
 		{
@@ -6385,7 +6391,7 @@
 			"classSource": "XUA2023PlayersHandbookP6",
 			"level": 18,
 			"entries": [
-				"Your connection to the forces of nature grants you {@feat Blindsight|XUA2023PlayersHandbookP6} with a range of 30 feet."
+				"Your connection to the forces of nature grants you {@sense Blindsight|XUA2023PlayersHandbookP6} with a range of 30 feet."
 			]
 		},
 		{
@@ -6431,7 +6437,7 @@
 			"classSource": "XUA2023PlayersHandbookP6",
 			"level": 1,
 			"entries": [
-				"You know how to turn a subtle attack into a deadly one. Once on each of your turns when you take the {@action Attack|XUA2023PlayersHandbookP6} Action, you can deal extra damage to one creature you hit with an {@variantrule Attack Roll|XUA2023PlayersHandbookP6} if you're attacking with a Finesse Weapon or a Ranged Weapon and if at least one of the following requirements is met:",
+				"You know how to turn a subtle attack into a deadly one. Once on each of your turns when you take the {@action Attack|XUA2023PlayersHandbookP6} Action, you can deal extra damage to one creature you hit with an attack roll if you're attacking with a Finesse Weapon or a Ranged Weapon and if at least one of the following requirements is met:",
 				{
 					"type": "list",
 					"style": "list-hang-notitle",
@@ -6440,7 +6446,7 @@
 							"type": "item",
 							"name": "Advantage",
 							"entries": [
-								"You have Advantage on the {@variantrule Attack Roll|XUA2023PlayersHandbookP6}."
+								"You have Advantage on the attack roll."
 							]
 						},
 						{
@@ -6486,7 +6492,7 @@
 			"classSource": "XUA2023PlayersHandbookP6",
 			"level": 2,
 			"entries": [
-				"Your quick thinking and agility allow you to move and act quickly. On your turn, you can take one of the following Actions as a Bonus Action: {@action Dash|XUA2023PlayersHandbookP6}, {@action Disengage}, or {@action Hide|XUA2023PlayersHandbookP6}."
+				"Your quick thinking and agility allow you to move and act quickly. On your turn, you can take one of the following Actions as a Bonus Action: {@action Dash}, {@action Disengage}, or {@action Hide|XUA2023PlayersHandbookP6}."
 			]
 		},
 		{
@@ -8254,7 +8260,7 @@
 			"subclassSource": "XUA2023PlayersHandbookP6",
 			"level": 3,
 			"entries": [
-				"You have attuned yourself with the elemental forces of the multiverse. You know the Elementalism cantrip.",
+				"You have attuned yourself with the elemental forces of the multiverse. You know the {@spell Elementalism|XUA2023PlayersHandbookP6} cantrip.",
 				"In addition, at the start of your turn, you can spend 1 Discipline Point to imbue yourself with elemental energy. The energy lasts for 10 minutes or until you have the {@condition Incapacitated|XUA2023PlayersHandbookP6} condition. You gain the following benefits for the duration:",
 				{
 					"type": "list",
@@ -9258,7 +9264,7 @@
 						],
 						[
 							"13th",
-							"{@spell Banishment}, {@spell Dimension Door}"
+							"{@spell Banishment|XUA2022ClericAndRevisedSpecies}, {@spell Dimension Door}"
 						],
 						[
 							"17th",
@@ -9389,7 +9395,7 @@
 			"level": 7,
 			"header": 2,
 			"entries": [
-				"When you use your Bonus Action to command your Primal Companion beast to take an action, you can also command it to take the {@action Dash}, Disengage, {@action Dodge}, or {@action Help} action as a Bonus Action.",
+				"When you use your Bonus Action to command your Primal Companion beast to take an action, you can also command it to take the {@action Dash}, {@action Disengage}, {@action Dodge}, or {@action Help} action as a Bonus Action.",
 				"In addition, whenever the beast hits with an attack and deals damage, it can deal your choice of Force damage or its normal damage type."
 			]
 		},
@@ -9761,6 +9767,142 @@
 			"header": 2,
 			"entries": [
 				"You gain another feature option of your choice from the Defensive Tactics feature."
+			]
+		},
+		{
+			"name": "Arcane Trickster",
+			"source": "XUA2023PlayersHandbookP6",
+			"page": 51,
+			"className": "Rogue",
+			"classSource": "XUA2023PlayersHandbookP6",
+			"subclassShortName": "Arcane Trickster",
+			"subclassSource": "XUA2023PlayersHandbookP6",
+			"level": 3,
+			"entries": [
+				"Some Rogues enhance their fine-honed skills of stealth and agility with Arcane spells, learning magical tricks to aid them in their trade. Some Arcane Tricksters use their talents as pickpockets and burglars, while others are pranksters, mischief-makers, or adventurers.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellcasting|Rogue|XUA2023PlayersHandbookP6|Arcane Trickster|XUA2023PlayersHandbookP6|3|XUA2023PlayersHandbookP6"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mage Hand Legerdemain|Rogue|XUA2023PlayersHandbookP6|Arcane Trickster|XUA2023PlayersHandbookP6|3"
+				}
+			]
+		},
+		{
+			"name": "Mage Hand Legerdemain",
+			"source": "XUA2023PlayersHandbookP6",
+			"page": 52,
+			"className": "Rogue",
+			"classSource": "XUA2023PlayersHandbookP6",
+			"subclassShortName": "Arcane Trickster",
+			"subclassSource": "XUA2023PlayersHandbookP6",
+			"level": 3,
+			"entries": [
+				"When you cast {@spell Mage Hand}, you can make the spectral hand {@condition invisible}. You can control the hand as a Bonus Action, instead of an action, and through it, you can use Thieves' Tools and make Dexterity ({@skill Sleight of Hand}) checks."
+			]
+		},
+		{
+			"name": "Spellcasting",
+			"source": "XUA2023PlayersHandbookP6",
+			"page": 52,
+			"className": "Rogue",
+			"classSource": "XUA2023PlayersHandbookP6",
+			"subclassShortName": "Arcane Trickster",
+			"subclassSource": "XUA2023PlayersHandbookP6",
+			"level": 3,
+			"entries": [
+				"You have learned to cast spells. See the Player's Handbook for the rules on spellcasting. The information below details how you use those rules as an Arcane Trickster.",
+				{
+					"type": "entries",
+					"name": "Cantrips",
+					"entries": [
+						"You know three cantrips: Mage Hand and two other cantrips of your choice from the Arcane spell list.",
+						"Whenever you gain a Rogue level, you can replace one of your cantrips, except Mage Hand, with another cantrip of your choice from the Arcane spell list.",
+						"When you reach 10th level in this class, you learn another Arcane cantrip of your choice."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spell Slots",
+					"entries": [
+						"The Arcane Trickster Spellcasting table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a {@variantrule Long Rest|XUA2023PlayersHandbookP6}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Prepared Spells of 1st+ Level",
+					"entries": [
+						"You prepare a list of spells of 1st level and higher that are available for you to cast with this feature. To start, choose three 1st-level spells from the Arcane spell list, two of which must be from the Enchantment and Illusion schools of magic.",
+						"The number of spells on your list increases as you gain Rogue levels, as shown in the Prepared Spells column of the Arcane Trickster Spellcasting table. Whenever that number increases, choose additional spells from the Arcane spell list until the number of spells on your list matches the number on the table. The chosen spells must be of a level for which you have spell slots. For example, if you're a 7th-level Rogue, your list of prepared spells can include six Arcane spells of 1st or 2nd level, in any combination."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Changing Your Prepared Spells",
+					"entries": [
+						"Whenever you gain a level in this class, you can replace one of the spells you know with another spell of your choice from the Arcane spell list. The new spell must be of a level for which you have spell slots."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Ability",
+					"entries": [
+						"Intelligence is your spellcasting ability for your Arcane Trickster spells."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Focus",
+					"entries": [
+						"You can use an Arcane Focus as a Spellcasting Focus for the spells you prepare for this subclass."
+					]
+				}
+			]
+		},
+		{
+			"name": "Magical Ambush",
+			"source": "XUA2023PlayersHandbookP6",
+			"page": 52,
+			"className": "Rogue",
+			"classSource": "XUA2023PlayersHandbookP6",
+			"subclassShortName": "Arcane Trickster",
+			"subclassSource": "XUA2023PlayersHandbookP6",
+			"level": 9,
+			"header": 2,
+			"entries": [
+				"If you have the {@condition Invisible|XUA2023PlayersHandbookP6} condition when you cast a spell on a creature, it has Disadvantage on any saving throw it makes against the spell on the same turn."
+			]
+		},
+		{
+			"name": "Versatile Trickster",
+			"source": "XUA2023PlayersHandbookP6",
+			"page": 52,
+			"className": "Rogue",
+			"classSource": "XUA2023PlayersHandbookP6",
+			"subclassShortName": "Arcane Trickster",
+			"subclassSource": "XUA2023PlayersHandbookP6",
+			"level": 13,
+			"header": 2,
+			"entries": [
+				"You gain the ability to distract targets with your Mage Hand. When you use the Disarm or Trip options of your Cunning Strike, you can also target that option at a creature within 5 feet of the spectral hand."
+			]
+		},
+		{
+			"name": "Spell Thief",
+			"source": "XUA2023PlayersHandbookP6",
+			"page": 52,
+			"className": "Rogue",
+			"classSource": "XUA2023PlayersHandbookP6",
+			"subclassShortName": "Arcane Trickster",
+			"subclassSource": "XUA2023PlayersHandbookP6",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"You gain the ability to magically steal the knowledge of how to cast a spell from another spellcaster.",
+				"Immediately after a creature casts a spell that targets you or includes you in its area of effect, you can use your Reaction to force the creature to make a saving throw with its spellcasting ability modifier. The DC equals your Spell Save DC. On a failed save, you negate the spell's effect against you, and you steal the knowledge of the spell if it is at least 1st level and of a level you can cast (it doesn't need to be an Arcane spell). For the next 8 hours, you know the spell and can cast it using your spell slots. The creature can't cast that spell until the 8 hours have passed.",
+				"Once you use this feature, you can't use it again until you finish a {@variantrule Long Rest|XUA2023PlayersHandbookP6}."
 			]
 		},
 		{
@@ -10182,142 +10324,6 @@
 			"entries": [
 				"You are adept at laying ambushes and quickly escaping danger. You can take two turns during the first round of any combat. You take your first turn at your normal Initiative and your second turn at your Initiative minus 10."
 			]
-		},
-		{
-			"name": "Arcane Trickster",
-			"source": "XUA2023PlayersHandbookP6",
-			"page": 51,
-			"className": "Rogue",
-			"classSource": "XUA2023PlayersHandbookP6",
-			"subclassShortName": "Trickster",
-			"subclassSource": "XUA2023PlayersHandbookP6",
-			"level": 3,
-			"entries": [
-				"Some Rogues enhance their fine-honed skills of stealth and agility with Arcane spells, learning magical tricks to aid them in their trade. Some Arcane Tricksters use their talents as pickpockets and burglars, while others are pranksters, mischief-makers, or adventurers.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Spellcasting|Rogue|XUA2023PlayersHandbookP6|Trickster|XUA2023PlayersHandbookP6|3"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Mage Hand Legerdemain|Rogue|XUA2023PlayersHandbookP6|Trickster|XUA2023PlayersHandbookP6|3"
-				}
-			]
-		},
-		{
-			"name": "Mage Hand Legerdemain",
-			"source": "XUA2023PlayersHandbookP6",
-			"page": 52,
-			"className": "Rogue",
-			"classSource": "XUA2023PlayersHandbookP6",
-			"subclassShortName": "Trickster",
-			"subclassSource": "XUA2023PlayersHandbookP6",
-			"level": 3,
-			"entries": [
-				"When you cast {@spell Mage Hand}, you can make the spectral hand {@condition invisible}. You can control the hand as a Bonus Action, instead of an action, and through it, you can use Thieves' Tools and make Dexterity ({@skill Sleight of Hand}) checks."
-			]
-		},
-		{
-			"name": "Spellcasting",
-			"source": "XUA2023PlayersHandbookP6",
-			"page": 52,
-			"className": "Rogue",
-			"classSource": "XUA2023PlayersHandbookP6",
-			"subclassShortName": "Trickster",
-			"subclassSource": "XUA2023PlayersHandbookP6",
-			"level": 3,
-			"entries": [
-				"You have learned to cast spells. See the Player's Handbook for the rules on spellcasting. The information below details how you use those rules as an Arcane Trickster.",
-				{
-					"type": "entries",
-					"name": "Cantrips",
-					"entries": [
-						"You know three cantrips: Mage Hand and two other cantrips of your choice from the Arcane spell list.",
-						"Whenever you gain a Rogue level, you can replace one of your cantrips, except Mage Hand, with another cantrip of your choice from the Arcane spell list.",
-						"When you reach 10th level in this class, you learn another Arcane cantrip of your choice."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Spell Slots",
-					"entries": [
-						"The Arcane Trickster Spellcasting table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a {@variantrule Long Rest|XUA2023PlayersHandbookP6}."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Prepared Spells of 1st+ Level",
-					"entries": [
-						"You prepare a list of spells of 1st level and higher that are available for you to cast with this feature. To start, choose three 1st-level spells from the Arcane spell list, two of which must be from the Enchantment and Illusion schools of magic.",
-						"The number of spells on your list increases as you gain Rogue levels, as shown in the Prepared Spells column of the Arcane Trickster Spellcasting table. Whenever that number increases, choose additional spells from the Arcane spell list until the number of spells on your list matches the number on the table. The chosen spells must be of a level for which you have spell slots. For example, if you're a 7th-level Rogue, your list of prepared spells can include six Arcane spells of 1st or 2nd level, in any combination."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Changing Your Prepared Spells",
-					"entries": [
-						"Whenever you gain a level in this class, you can replace one of the spells you know with another spell of your choice from the Arcane spell list. The new spell must be of a level for which you have spell slots."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Spellcasting Ability",
-					"entries": [
-						"Intelligence is your spellcasting ability for your Arcane Trickster spells."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Spellcasting Focus",
-					"entries": [
-						"You can use an Arcane Focus as a Spellcasting Focus for the spells you prepare for this subclass."
-					]
-				}
-			]
-		},
-		{
-			"name": "Magical Ambush",
-			"source": "XUA2023PlayersHandbookP6",
-			"page": 52,
-			"className": "Rogue",
-			"classSource": "XUA2023PlayersHandbookP6",
-			"subclassShortName": "Trickster",
-			"subclassSource": "XUA2023PlayersHandbookP6",
-			"level": 9,
-			"header": 2,
-			"entries": [
-				"If you have the {@condition Invisible|XUA2023PlayersHandbookP6} condition when you cast a spell on a creature, it has Disadvantage on any saving throw it makes against the spell on the same turn."
-			]
-		},
-		{
-			"name": "Versatile Trickster",
-			"source": "XUA2023PlayersHandbookP6",
-			"page": 52,
-			"className": "Rogue",
-			"classSource": "XUA2023PlayersHandbookP6",
-			"subclassShortName": "Trickster",
-			"subclassSource": "XUA2023PlayersHandbookP6",
-			"level": 13,
-			"header": 2,
-			"entries": [
-				"You gain the ability to distract targets with your Mage Hand. When you use the Disarm or Trip options of your Cunning Strike, you can also target that option at a creature within 5 feet of the spectral hand."
-			]
-		},
-		{
-			"name": "Spell Thief",
-			"source": "XUA2023PlayersHandbookP6",
-			"page": 52,
-			"className": "Rogue",
-			"classSource": "XUA2023PlayersHandbookP6",
-			"subclassShortName": "Trickster",
-			"subclassSource": "XUA2023PlayersHandbookP6",
-			"level": 17,
-			"header": 2,
-			"entries": [
-				"You gain the ability to magically steal the knowledge of how to cast a spell from another spellcaster.",
-				"Immediately after a creature casts a spell that targets you or includes you in its area of effect, you can use your Reaction to force the creature to make a saving throw with its spellcasting ability modifier. The DC equals your Spell Save DC. On a failed save, you negate the spell's effect against you, and you steal the knowledge of the spell if it is at least 1st level and of a level you can cast (it doesn't need to be an Arcane spell). For the next 8 hours, you know the spell and can cast it using your spell slots. The creature can't cast that spell until the 8 hours have passed.",
-				"Once you use this feature, you can't use it again until you finish a {@variantrule Long Rest|XUA2023PlayersHandbookP6}."
-			]
 		}
 	],
 	"feat": [
@@ -10379,7 +10385,7 @@
 			],
 			"repeatable": false,
 			"entries": [
-				"You gain a +2 bonus to {@variantrule Attack Roll|XUA2023PlayersHandbookP6} you make with Ranged Weapons."
+				"You gain a +2 bonus to attack roll you make with Ranged Weapons."
 			]
 		},
 		{
@@ -10447,7 +10453,7 @@
 			],
 			"repeatable": false,
 			"entries": [
-				"Immediately after a creature you can see makes an {@variantrule Attack Roll|XUA2023PlayersHandbookP6} and hits a target other than you that is within 5 feet of you, you can use your Reaction to interpose your Shield and impose a \u22122 penalty on the {@variantrule Attack Roll|XUA2023PlayersHandbookP6}, potentially turning it into a miss. You must be wielding a Shield to use this Reaction."
+				"Immediately after a creature you can see makes an attack roll and hits a target other than you that is within 5 feet of you, you can use your Reaction to interpose your Shield and impose a \u22122 penalty on the attack roll, potentially turning it into a miss. You must be wielding a Shield to use this Reaction."
 			]
 		},
 		{
@@ -10464,7 +10470,7 @@
 			],
 			"repeatable": false,
 			"entries": [
-				"When you make the extra attack of the {@variantrule Light|XUA2023PlayersHandbookP6} weapon property, you can add your Ability Modifier to the damage of the extra attack."
+				"When you make the extra attack of the {@itemProperty XUA2023PlayersHandbookP6-L|XUA2023PlayersHandbookP6|Light} weapon property, you can add your Ability Modifier to the damage of the extra attack."
 			]
 		}
 	],
@@ -11370,11 +11376,11 @@
 			"source": "XUA2023PlayersHandbookP6",
 			"spellListType": "groups",
 			"spells": [
-				"elementalism",
-				"frostbite",
-				"mind sliver",
-				"thunderclap",
-				"toll the dead",
+				"elementalism|XUA2023PlayersHandbookP6",
+				"frostbite|xge",
+				"mind sliver|tce",
+				"thunderclap|xge",
+				"toll the dead|xge",
 				"acid splash",
 				"blade ward",
 				"chill touch",
@@ -11491,7 +11497,7 @@
 				"vampiric touch",
 				"water breathing",
 				"arcane eye",
-				"banishment",
+				"banishment|XUA2022ClericAndRevisedSpecies",
 				"blight",
 				"compulsion",
 				"confusion",
@@ -11605,11 +11611,11 @@
 			"source": "XUA2023PlayersHandbookP6",
 			"spellListType": "groups",
 			"spells": [
-				"toll the dead",
-				"word of radiance",
+				"toll the dead|xge",
+				"word of radiance|xge",
 				"guidance",
 				"light",
-				"resistance",
+				"resistance|XUA2022ClericAndRevisedSpecies",
 				"sacred flame",
 				"spare the dying",
 				"thaumaturgy",
@@ -11666,7 +11672,7 @@
 				"tongues",
 				"aura of life",
 				"aura of purity",
-				"banishment",
+				"banishment|XUA2022ClericAndRevisedSpecies",
 				"death ward",
 				"divination",
 				"freedom of movement",
@@ -11720,16 +11726,16 @@
 			"source": "XUA2023PlayersHandbookP6",
 			"spellListType": "groups",
 			"spells": [
-				"elementalism",
-				"frostbite",
-				"thunderclap",
+				"elementalism|XUA2023PlayersHandbookP6",
+				"frostbite|xge",
+				"thunderclap|xge",
 				"druidcraft",
 				"guidance",
 				"mending",
 				"message",
 				"poison spray",
 				"produce flame",
-				"resistance",
+				"resistance|XUA2022ClericAndRevisedSpecies",
 				"shillelagh",
 				"spare the dying",
 				"thorn whip",
@@ -11752,7 +11758,7 @@
 				"thunderwave",
 				"animal messenger",
 				"augury",
-				"barkskin",
+				"barkskin|XUA2022ClericAndRevisedSpecies",
 				"beast sense",
 				"cordon of arrows",
 				"darkvision",
@@ -13277,7 +13283,7 @@
 			"page": 72,
 			"entries": [
 				"Expertise is a special feature that enhances your use of a particular Skill Proficiency. If you gain {@variantrule Expertise|XUA2023PlayersHandbookP6}, you gain it in one Skill in which you have Proficiency. You can never have {@variantrule Expertise|XUA2023PlayersHandbookP6} in the same Skill Proficiency more than once.",
-				"When you make an {@variantrule {@variantrule Ability Check|XUA2023PlayersHandbookP6}|XUA2023PlayersHandbookP6} with a Skill Proficiency in which you have {@variantrule Expertise|XUA2023PlayersHandbookP6}, your Proficiency Bonus is doubled for that check."
+				"When you make an {@variantrule Ability Check|XUA2022ClericAndRevisedSpecies} with a Skill Proficiency in which you have {@variantrule Expertise|XUA2023PlayersHandbookP6}, your Proficiency Bonus is doubled for that check."
 			]
 		},
 		{
@@ -13372,7 +13378,7 @@
 											"type": "item",
 											"name": "Exhaustion Reduced",
 											"entries": [
-												"If you are {@condition Exhausted|XUA2023PlayersHandbookP6}, your level of {@condition exhaustion} decreases by 1."
+												"If you are {@condition Exhausted|XUA2023DruidAndPaladin}, your level of exhaustion decreases by 1."
 											]
 										},
 										{
@@ -13461,7 +13467,7 @@
 					"items": [
 						"{@variantrule Armor Training|XUA2023PlayersHandbookP6}",
 						"{@action Attack|XUA2023PlayersHandbookP6}",
-						"{@variantrule Blindsight|XUA2023PlayersHandbookP6}",
+						"{@sense Blindsight|XUA2023PlayersHandbookP6}",
 						"{@variantrule Climb Speed|XUA2023PlayersHandbookP6}",
 						"{@variantrule Creature Type|XUA2023PlayersHandbookP6}",
 						"{@variantrule D20 Tests|XUA2023PlayersHandbookP6}",
@@ -13489,8 +13495,8 @@
 						"{@variantrule Telepathy|XUA2023PlayersHandbookP6}",
 						"{@variantrule Teleportation|XUA2023PlayersHandbookP6}",
 						"{@variantrule Tool Proficiency|XUA2023PlayersHandbookP6}",
-						"{@variantrule Tremorsense|XUA2023PlayersHandbookP6}",
-						"{@variantrule Truesight|XUA2023PlayersHandbookP6}",
+						"{@sense Tremorsense|XUA2023PlayersHandbookP6}",
+						"{@sense Truesight|XUA2023PlayersHandbookP6}",
 						"{@variantrule Unarmed Strike|XUA2023PlayersHandbookP6}",
 						"{@condition Unconscious|XUA2023PlayersHandbookP6}"
 					]
@@ -13619,7 +13625,7 @@
 								],
 								[
 									"0",
-									"{@spell Frostbite}",
+									"{@spell Frostbite|XGE}",
 									"Evocation",
 									"No"
 								],
@@ -13649,7 +13655,7 @@
 								],
 								[
 									"0",
-									"{@spell Mind Sliver}",
+									"{@spell Mind Sliver|TCE}",
 									"Enchantment",
 									"No"
 								],
@@ -13685,13 +13691,13 @@
 								],
 								[
 									"0",
-									"{@spell Thunderclap}",
+									"{@spell Thunderclap|XGE}",
 									"Evocation",
 									"No"
 								],
 								[
 									"0",
-									"{@spell Toll the Dead}",
+									"{@spell Toll the Dead|XGE}",
 									"Necromancy",
 									"No"
 								],
@@ -13883,7 +13889,7 @@
 								],
 								[
 									"1",
-									"{@spell Tenser 's Floating Disk}",
+									"{@spell Tenser's Floating Disk}",
 									"Conjuration",
 									"Yes"
 								],
@@ -14027,7 +14033,7 @@
 								],
 								[
 									"2",
-									"{@spell Magic Aura}",
+									"{@spell Nystul's Magic Aura|PHB|Magic Aura}",
 									"Illusion",
 									"No"
 								],
@@ -14297,7 +14303,7 @@
 								],
 								[
 									"4",
-									"{@spell Banishment}",
+									"{@spell Banishment|XUA2022ClericAndRevisedSpecies}",
 									"Abjuration",
 									"No"
 								],
@@ -14633,7 +14639,7 @@
 								],
 								[
 									"6",
-									"{@spell Instant Summons}",
+									"{@spell Drawmij's Instant Summons|PHB|Instant Summons}",
 									"Conjuration",
 									"Yes"
 								],
@@ -14965,7 +14971,7 @@
 							"rows": [
 								[
 									"0",
-									"{@u {@spell Guidance|XUA2023PlayersHandbookP6}}",
+									"{@u {@spell Guidance|XUA2022ClericAndRevisedSpecies}}",
 									"Divination",
 									"No"
 								],
@@ -14977,7 +14983,7 @@
 								],
 								[
 									"0",
-									"{@u {@spell Resistance|XUA2023PlayersHandbookP6}}",
+									"{@u {@spell Resistance|XUA2022ClericAndRevisedSpecies}}",
 									"Abjuration",
 									"No"
 								],
@@ -15001,13 +15007,13 @@
 								],
 								[
 									"0",
-									"{@spell Toll the Dead}",
+									"{@spell Toll the Dead|XGE}",
 									"Necromancy",
 									"No"
 								],
 								[
 									"0",
-									"{@spell Word of Radiance}",
+									"{@spell Word of Radiance|XGE}",
 									"Evocation",
 									"No"
 								],
@@ -15031,7 +15037,7 @@
 								],
 								[
 									"1",
-									"{@spell Commpelled Duel}",
+									"{@spell Compelled Duel}",
 									"Enchantment",
 									"No"
 								],
@@ -15193,7 +15199,7 @@
 								],
 								[
 									"2",
-									"{@u {@spell Prayer of Healing|XUA2023PlayersHandbookP6}}",
+									"{@u {@spell Prayer of Healing|XUA2022ClericAndRevisedSpecies}}",
 									"Abjuration*",
 									"No"
 								],
@@ -15337,7 +15343,7 @@
 								],
 								[
 									"4",
-									"{@u {@spell Banishment|XUA2023PlayersHandbookP6}}",
+									"{@u {@spell Banishment|XUA2022ClericAndRevisedSpecies}}",
 									"Conjuration*",
 									"No"
 								],
@@ -15663,7 +15669,7 @@
 								],
 								[
 									"0",
-									"{@spell Frostbite}",
+									"{@spell Frostbite|XGE}",
 									"Evocation",
 									"No"
 								],
@@ -15699,7 +15705,7 @@
 								],
 								[
 									"0",
-									"{@u {@spell Resistance|XUA2023PlayersHandbookP6}}",
+									"{@u {@spell Resistance|XUA2022ClericAndRevisedSpecies}}",
 									"Abjuration",
 									"No"
 								],
@@ -15723,7 +15729,7 @@
 								],
 								[
 									"0",
-									"{@spell Thunderclap}",
+									"{@spell Thunderclap|XGE}",
 									"Evocation",
 									"No"
 								],
@@ -15843,7 +15849,7 @@
 								],
 								[
 									"2",
-									"{@u {@spell Barkskin|XUA2023PlayersHandbookP6}}",
+									"{@u {@spell Barkskin|XUA2022ClericAndRevisedSpecies}}",
 									"Transmut.",
 									"No"
 								],
@@ -16957,7 +16963,7 @@
 							"type": "item",
 							"name": "Attacks Affected",
 							"entries": [
-								"{@action Attack|XUA2023PlayersHandbookP6} rolls against you have Disadvantage, and your attack rolls have Advantage. If a creature can somehow see you, as with magic or {@variantrule Blindsight|XUA2023PlayersHandbookP6}, you don't gain this benefit against that creature."
+								"{@action Attack|XUA2023PlayersHandbookP6} rolls against you have Disadvantage, and your attack rolls have Advantage. If a creature can somehow see you, as with magic or {@sense Blindsight|XUA2023PlayersHandbookP6}, you don't gain this benefit against that creature."
 							]
 						}
 					]
@@ -17097,7 +17103,7 @@
 			],
 			"entries": [
 				"With the {@action Hide|XUA2023PlayersHandbookP6} Action, you try to conceal yourself. To do so, you must make a {@dc 15} Dexterity Check ({@skill Stealth}) while you're Heavily Obscured or behind Three-Quarters Cover or Total Cover, and you must be out of any visible enemy's line of sight; if you can see a creature, you can discern whether it can see you.",
-				"On a successful check, you are {@condition Hidden|XUA2023PlayersHandbookP6}. Make note of your check's total, which becomes the DC for a creature to find you with a Wisdom Check ({@skill Perception}).",
+				"On a successful check, you are Hidden. Make note of your check's total, which becomes the DC for a creature to find you with a Wisdom Check ({@skill Perception}).",
 				"The condition ends on you immediately after any of the following occurrences: you make a sound louder than a whisper, an enemy finds you, you make an attack roll, or you cast a spell with a verbal component."
 			]
 		},

--- a/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 7.json
+++ b/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 7.json
@@ -5,16 +5,16 @@
 				"json": "XUA2023PlayersHandbookP7",
 				"abbreviation": "XUA23P7",
 				"full": "Unearthed Arcana 2023: Player's Handbook Playtest 7",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/ph-playtest7/tsgOb3llF22AL0nU/UA2023-PH-Playtest7.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2023-09-07",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy",
 					"Lyra"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/ph-playtest7/tsgOb3llF22AL0nU/UA2023-PH-Playtest7.pdf",
-				"dateReleased": "2023-09-07"
+				]
 			}
 		],
 		"dependencies": {
@@ -26,6 +26,12 @@
 		"dateAdded": 1691158917,
 		"dateLastModified": 1733837795,
 		"_dateLastModifiedHash": "7bb3ac20d1"
+	},
+	"_test": {
+		"references": [
+			"XUA2022ClericAndRevisedSpecies",
+			"XUA2023PlayersHandbookP7"
+		]
 	},
 	"class": [
 		{
@@ -364,7 +370,7 @@
 					"{@item Crossbow Bolts (20)|phb}",
 					"{@item Quiver|phb}",
 					"{@item Dungeoneer's Pack|phb}",
-					"(a) {@item Greatsword} or (b) {@item Longsword}, {@item shield|phb} and 25 GP",
+					"(a) {@item Greatsword|PHB} or (b) {@item Longsword|PHB}, {@item shield|phb} and 25 GP",
 					"11 GP"
 				],
 				"goldAlternative": "175 GP"
@@ -1513,7 +1519,7 @@
 					"{@item Arcane Focus|phb} (Quarterstaff)",
 					"{@item Scholar's Pack|phb}",
 					"{@item Dagger|phb} (2)",
-					"{@item Robe|phb}",
+					"{@item Robes|phb|Robe}",
 					"5 GP"
 				],
 				"goldAlternative": "55"
@@ -11718,7 +11724,7 @@
 									"name": "Sorcerer Subclasses",
 									"page": 22,
 									"entries": [
-										"A Sorcerer subclass is a specialization that grants you special abilities at certain Sorcerer levels, as specified in the subclass. This section presents the following subclasses: {@class Sorcerer|XUA2023PlayersHandbookP7|Draconic Sorcery|Draconic|XUA2023PlayersHandbookP7} and {@class Sorcerer|XUA2023PlayersHandbookP7|Wild Magic Sorcery|Wild Magic|XUA2023PlayersHandbookP7}. See {@book Tasha's Cauldron of Everything|TCE} for {@class Sorcerer|XUA2023PlayersHandbookP7|Aberrant Sorcery|Aberrant|XUA2023PlayersHandbookP7} (aka {@class Sorcerer|PHB|Aberrant Mind|Aberrant Mind|TCE}) and {@class Sorcerer|XUA2023PlayersHandbookP7|Clockwork Sorcery|Clockwork|XUA2023PlayersHandbookP7} (aka {@class Sorcerer|PHB|Clockwork Soul|Clockwork Soul|TCE}).",
+										"A Sorcerer subclass is a specialization that grants you special abilities at certain Sorcerer levels, as specified in the subclass. This section presents the following subclasses: {@class Sorcerer|XUA2023PlayersHandbookP7|Draconic Sorcery|Draconic|XUA2023PlayersHandbookP7} and {@class Sorcerer|XUA2023PlayersHandbookP7|Wild Magic Sorcery|Wild|XUA2023PlayersHandbookP7}. See {@book Tasha's Cauldron of Everything|TCE} for {@class Sorcerer|XUA2023PlayersHandbookP7|Aberrant Sorcery|Aberrant|XUA2023PlayersHandbookP7} (aka {@class Sorcerer|PHB|Aberrant Mind|Aberrant Mind|TCE}) and {@class Sorcerer|XUA2023PlayersHandbookP7|Clockwork Sorcery|Clockwork|XUA2023PlayersHandbookP7} (aka {@class Sorcerer|PHB|Clockwork Soul|Clockwork Soul|TCE}).",
 										{
 											"type": "entries",
 											"name": "Draconic Sorcery",
@@ -12797,7 +12803,7 @@
 									"name": "Wizard Subclasses",
 									"page": 39,
 									"entries": [
-										"A Wizard subclass is a specialization that grants you special abilities at certain Wizard levels, as specified in the subclass. This section presents the following subclasses: {@class Wizard|XUA2023PlayersHandbookP7|Abjurer|Abjurer|XUA2023PlayersHandbookP7}, {@class Wizard|XUA2023PlayersHandbookP7|Diviner|Diviner|XUA2023PlayersHandbookP7}, {@class Wizard|XUA2023PlayersHandbookP7|Evoker|Evoker|XUA2023PlayersHandbookP7}, and {@class Wizard|XUA2023PlayersHandbookP7|Illusionist|Illusionist|XUA2023PlayersHandbookP7}.",
+										"A Wizard subclass is a specialization that grants you special abilities at certain Wizard levels, as specified in the subclass. This section presents the following subclasses: {@class Wizard|XUA2023PlayersHandbookP7|Abjurer|Abjuration|XUA2023PlayersHandbookP7}, {@class Wizard|XUA2023PlayersHandbookP7|Diviner|Divination|XUA2023PlayersHandbookP7}, {@class Wizard|XUA2023PlayersHandbookP7|Evoker|Evocation|XUA2023PlayersHandbookP7}, and {@class Wizard|XUA2023PlayersHandbookP7|Illusionist|Illusion|XUA2023PlayersHandbookP7}.",
 										{
 											"type": "entries",
 											"name": "Abjurer",
@@ -12851,7 +12857,7 @@
 													"classSource": "XUA2023PlayersHandbookP7",
 													"page": 39,
 													"collapsed": true,
-													"shortName": "Abjurer"
+													"shortName": "Abjuration"
 												}
 											],
 											"id": "03c"
@@ -12901,7 +12907,7 @@
 													"classSource": "XUA2023PlayersHandbookP7",
 													"page": 40,
 													"collapsed": true,
-													"shortName": "Diviner"
+													"shortName": "Divination"
 												}
 											],
 											"id": "03e"
@@ -12959,7 +12965,7 @@
 													"classSource": "XUA2023PlayersHandbookP7",
 													"page": 41,
 													"collapsed": true,
-													"shortName": "Evoker"
+													"shortName": "Evocation"
 												}
 											],
 											"id": "040"
@@ -13025,7 +13031,7 @@
 													"classSource": "XUA2023PlayersHandbookP7",
 													"page": 42,
 													"collapsed": true,
-													"shortName": "Illusionist"
+													"shortName": "Illusion"
 												}
 											],
 											"id": "042"

--- a/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 8.json
+++ b/collection/Unearthed Arcana 2023 - Player's Handbook Playtest 8.json
@@ -5,16 +5,16 @@
 				"json": "XUA2023PlayersHandbookP8",
 				"abbreviation": "XUA23P8",
 				"full": "Unearthed Arcana 2023: Player's Handbook Playtest 8",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/ph-playtest8/gHvtmY50loGLgQUb/UA2023-PH-Playtest8.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2023-11-27",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy",
 					"Lyra"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/ph-playtest8/gHvtmY50loGLgQUb/UA2023-PH-Playtest8.pdf",
-				"dateReleased": "2023-11-27"
+				]
 			}
 		],
 		"dependencies": {
@@ -1361,10 +1361,10 @@
 							"vampiric touch"
 						],
 						"7": [
-							"fount of moonlight"
+							"fount of moonlight|XUA2023PlayersHandbookP8"
 						],
 						"9": [
-							"dawn"
+							"dawn|xge"
 						]
 					}
 				}

--- a/collection/Unearthed Arcana 2025 - Eberron Updates.json
+++ b/collection/Unearthed Arcana 2025 - Eberron Updates.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025EberronUpdates",
 				"abbreviation": "XUA2025EU",
 				"full": "Unearthed Arcana 2025: Eberron Updates",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/eberron-updates/Lhg25Ggx5iY3rETH/UA2025-CartographerArtificer.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-02-27",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/eberron-updates/Lhg25Ggx5iY3rETH/UA2025-CartographerArtificer.pdf",
-				"dateReleased": "2025-02-27"
+				]
 			}
 		],
 		"dependencies": {
@@ -33,6 +33,11 @@
 		"dateAdded": 1740677812,
 		"dateLastModified": 1764502955,
 		"_dateLastModifiedHash": "678f164be1"
+	},
+	"_test": {
+		"references": [
+			"XUA2024Artificer"
+		]
 	},
 	"class": [
 		{
@@ -1797,7 +1802,7 @@
 					"type": "entries",
 					"name": "Improved Intuition",
 					"entries": [
-						"When you use the Medical Intuition benefit of your {@feat Mark of Healing|XPHB} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+						"When you use the Medical Intuition benefit of your {@feat Mark of Healing|XUA2025EberronUpdates} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
 					]
 				},
 				{

--- a/collection/Wayfinder's Guide to Eberron.json
+++ b/collection/Wayfinder's Guide to Eberron.json
@@ -5,15 +5,15 @@
 				"json": "UAWayfindersGuideToEberron",
 				"abbreviation": "WGE",
 				"full": "Wayfinder's Guide to Eberron",
+				"url": "https://www.dmsguild.com/product/247882/Wayfinders-Guide-to-Eberron-5e",
+				"version": "1.0.0",
+				"dateReleased": "2018-07-23",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://www.dmsguild.com/product/247882/Wayfinders-Guide-to-Eberron-5e",
-				"dateReleased": "2018-07-23"
+				]
 			}
 		],
 		"edition": "classic",

--- a/feat/Unearthed Arcana - Feats for Races.json
+++ b/feat/Unearthed Arcana - Feats for Races.json
@@ -5,15 +5,15 @@
 				"json": "UAFeatsForRaces",
 				"abbreviation": "UAFFR",
 				"full": "Unearthed Arcana: Feats for Races",
+				"url": "https://media.wizards.com/2017/dnd/downloads/RJSJC2017_04UASkillFeats_24v10.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-04-24",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/RJSJC2017_04UASkillFeats_24v10.pdf",
-				"dateReleased": "2017-04-24"
+				]
 			}
 		],
 		"edition": "classic",

--- a/feat/Unearthed Arcana - Feats for Skills.json
+++ b/feat/Unearthed Arcana - Feats for Skills.json
@@ -5,15 +5,15 @@
 				"json": "UAFeatsForSkills",
 				"abbreviation": "UAFFS",
 				"full": "Unearthed Arcana: Feats for Skills",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA-SkillFeats.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-04-17",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA-SkillFeats.pdf",
-				"dateReleased": "2017-04-17"
+				]
 			}
 		],
 		"edition": "classic",

--- a/feat/Unearthed Arcana - Feats.json
+++ b/feat/Unearthed Arcana - Feats.json
@@ -5,15 +5,15 @@
 				"json": "UAFeats",
 				"abbreviation": "UAFT",
 				"full": "Unearthed Arcana: Feats",
+				"url": "https://media.wizards.com/2016/downloads/DND/UA-Feats-V1.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-06-06",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/downloads/DND/UA-Feats-V1.pdf",
-				"dateReleased": "2016-06-06"
+				]
 			}
 		],
 		"edition": "classic",

--- a/feat/Unearthed Arcana 2020 - Feats.json
+++ b/feat/Unearthed Arcana 2020 - Feats.json
@@ -5,15 +5,15 @@
 				"json": "UA2020Feats",
 				"abbreviation": "UA20F",
 				"full": "Unearthed Arcana: 2020 Feats",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_Feats.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-07-13",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_Feats.pdf",
-				"dateReleased": "2020-07-13"
+				]
 			}
 		],
 		"edition": "classic",

--- a/item/Unearthed Arcana - Magic Items of Eberron.json
+++ b/item/Unearthed Arcana - Magic Items of Eberron.json
@@ -6,15 +6,15 @@
 				"json": "UAMagicItemsofEberron",
 				"abbreviation": "UAMIoE",
 				"full": "Unearthed Arcana: Magic Items of Eberron",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_Magic_Items_of_Eberron.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-10-08",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_Magic_Items_of_Eberron.pdf",
-				"dateReleased": "2018-10-08"
+				]
 			}
 		],
 		"internalCopies": [
@@ -24,6 +24,11 @@
 		"dateAdded": 1732050258,
 		"dateLastModified": 1759315511,
 		"_dateLastModifiedHash": "ba4676ac82"
+	},
+	"_test": {
+		"references": [
+			"UAWayfindersGuideToEberron"
+		]
 	},
 	"item": [
 		{

--- a/race/Unearthed Arcana - Centaurs and Minotaurs.json
+++ b/race/Unearthed Arcana - Centaurs and Minotaurs.json
@@ -5,15 +5,15 @@
 				"json": "UACentaursMinotaurs",
 				"abbreviation": "UACAM",
 				"full": "Unearthed Arcana: Centaurs and Minotaurs",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA-Centaur.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-05-14",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA-Centaur.pdf",
-				"dateReleased": "2018-05-14"
+				]
 			}
 		],
 		"edition": "classic",

--- a/race/Unearthed Arcana - Eladrin and Gith.json
+++ b/race/Unearthed Arcana - Eladrin and Gith.json
@@ -5,15 +5,15 @@
 				"json": "UAEladrinAndGith",
 				"abbreviation": "UAEaG",
 				"full": "Unearthed Arcana: Eladrin and Gith",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA-Eladrin-Gith.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-09-11",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA-Eladrin-Gith.pdf",
-				"dateReleased": "2017-09-11"
+				]
 			}
 		],
 		"edition": "classic",

--- a/race/Unearthed Arcana - Races of Eberron.json
+++ b/race/Unearthed Arcana - Races of Eberron.json
@@ -5,15 +5,15 @@
 				"json": "UARacesOfEberron",
 				"abbreviation": "UARoE",
 				"full": "Unearthed Arcana: Races of Eberron",
+				"url": "https://media.wizards.com/2018/dnd/downloads/723UA_EberronRaces7232018.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-07-23",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/723UA_EberronRaces7232018.pdf",
-				"dateReleased": "2018-07-23"
+				]
 			}
 		],
 		"edition": "classic",

--- a/race/Unearthed Arcana - Races of Ravnica.json
+++ b/race/Unearthed Arcana - Races of Ravnica.json
@@ -5,15 +5,15 @@
 				"json": "UARacesOfRavnica",
 				"abbreviation": "UARoR",
 				"full": "Unearthed Arcana: Races of Ravnica",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_RavnicaRaces.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-08-13",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_RavnicaRaces.pdf",
-				"dateReleased": "2018-08-13"
+				]
 			}
 		],
 		"edition": "classic",

--- a/race/Unearthed Arcana 2021 - Folk of the Feywild.json
+++ b/race/Unearthed Arcana 2021 - Folk of the Feywild.json
@@ -5,15 +5,15 @@
 				"json": "UA2021FolkOfTheFeywild",
 				"abbreviation": "UA21FF",
 				"full": "Unearthed Arcana: 2021 Folk of the Feywild",
+				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_FeyFolk.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-03-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_FeyFolk.pdf",
-				"dateReleased": "2020-03-12"
+				]
 			}
 		],
 		"edition": "classic",

--- a/race/Unearthed Arcana 2021 - Gothic Lineages.json
+++ b/race/Unearthed Arcana 2021 - Gothic Lineages.json
@@ -5,15 +5,15 @@
 				"json": "UA2021GothicLineages",
 				"abbreviation": "UA21GL",
 				"full": "Unearthed Arcana: 2021 Gothic Lineages",
+				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_GothicLineages.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-01-26",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_GothicLineages.pdf",
-				"dateReleased": "2020-01-26"
+				]
 			}
 		],
 		"edition": "classic",

--- a/race/Unearthed Arcana 2021 - Travelers of the Multiverse.json
+++ b/race/Unearthed Arcana 2021 - Travelers of the Multiverse.json
@@ -5,15 +5,15 @@
 				"json": "UA2021TravelersOfTheMultiverse",
 				"abbreviation": "UA21TotM",
 				"full": "Unearthed Arcana: 2021 Travelers of the Multiverse",
+				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_TravelersoftheMultiverse.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2021-10-08",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_TravelersoftheMultiverse.pdf",
-				"dateReleased": "2021-10-08"
+				]
 			}
 		],
 		"edition": "classic",

--- a/spell/Unearthed Arcana - Starter Spells.json
+++ b/spell/Unearthed Arcana - Starter Spells.json
@@ -5,15 +5,15 @@
 				"json": "UAStarterSpells",
 				"abbreviation": "UASS",
 				"full": "Unearthed Arcana: Starter Spells",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA-Starter-Spells.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-04-03",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA-Starter-Spells.pdf",
-				"dateReleased": "2017-04-03"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - A Trio of Subclasses.json
+++ b/subclass/Unearthed Arcana - A Trio of Subclasses.json
@@ -5,15 +5,15 @@
 				"json": "UAATrioOfSubclasses",
 				"abbreviation": "UAATOSC",
 				"full": "Unearthed Arcana: A Trio of Subclasses",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UAThreeSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-03-27",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UAThreeSubclasses.pdf",
-				"dateReleased": "2017-03-27"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Barbarian Primal Paths.json
+++ b/subclass/Unearthed Arcana - Barbarian Primal Paths.json
@@ -5,15 +5,15 @@
 				"json": "UABarbarianPrimalPaths",
 				"abbreviation": "UABPP",
 				"full": "Unearthed Arcana: Barbarian Primal Paths",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Barbarian.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-11-07",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Barbarian.pdf",
-				"dateReleased": "2016-11-07"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Barbarian and Monk.json
+++ b/subclass/Unearthed Arcana - Barbarian and Monk.json
@@ -5,15 +5,15 @@
 				"json": "UABarbarianAndMonk",
 				"abbreviation": "UABAM",
 				"full": "Unearthed Arcana: Barbarian and Monk",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-WildAstral.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-08-15",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-WildAstral.pdf",
-				"dateReleased": "2019-08-15"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Bard Bard Colleges.json
+++ b/subclass/Unearthed Arcana - Bard Bard Colleges.json
@@ -5,15 +5,15 @@
 				"json": "UABardBardColleges",
 				"abbreviation": "UABBC",
 				"full": "Unearthed Arcana: Bard: Bard Colleges",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Bard.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-11-14",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Bard.pdf",
-				"dateReleased": "2016-11-14"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Bard and Paladin.json
+++ b/subclass/Unearthed Arcana - Bard and Paladin.json
@@ -5,15 +5,15 @@
 				"json": "UABardAndPaladin",
 				"abbreviation": "UABAP",
 				"full": "Unearthed Arcana: Bard and Paladin",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-EloquentHeroics.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-09-18",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-EloquentHeroics.pdf",
-				"dateReleased": "2019-09-18"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Cleric Divine Domains.json
+++ b/subclass/Unearthed Arcana - Cleric Divine Domains.json
@@ -5,15 +5,15 @@
 				"json": "UAClericDivineDomains",
 				"abbreviation": "UACDD",
 				"full": "Unearthed Arcana: Cleric: Divine Domains",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Cleric.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-11-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Cleric.pdf",
-				"dateReleased": "2016-11-12"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "b2ae703123"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"subclass": [
 		{

--- a/subclass/Unearthed Arcana - Cleric, Druid, and Wizard.json
+++ b/subclass/Unearthed Arcana - Cleric, Druid, and Wizard.json
@@ -5,15 +5,15 @@
 				"json": "UAClericDruidWizard",
 				"abbreviation": "UACDW",
 				"full": "Unearthed Arcana: Cleric, Druid, and Wizard",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-TwilightFireNames.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-10-03",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-TwilightFireNames.pdf",
-				"dateReleased": "2019-10-03"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "1578ebe280"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"subclass": [
 		{

--- a/subclass/Unearthed Arcana - Druid.json
+++ b/subclass/Unearthed Arcana - Druid.json
@@ -5,15 +5,15 @@
 				"json": "UADruid",
 				"abbreviation": "UADrui",
 				"full": "Unearthed Arcana: Druid",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Druid11272016_CAWS.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-11-28",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UA_Druid11272016_CAWS.pdf",
-				"dateReleased": "2016-11-28"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Fighter, Ranger, and Rogue.json
+++ b/subclass/Unearthed Arcana - Fighter, Ranger, and Rogue.json
@@ -5,15 +5,15 @@
 				"json": "UAFighterRangerRogue",
 				"abbreviation": "UAFRR",
 				"full": "Unearthed Arcana: Fighter, Ranger, and Rogue",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-RuneSwarmRevived.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-10-17",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-RuneSwarmRevived.pdf",
-				"dateReleased": "2019-10-17"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Fighter, Rogue, and Wizard.json
+++ b/subclass/Unearthed Arcana - Fighter, Rogue, and Wizard.json
@@ -5,15 +5,15 @@
 				"json": "UAFighterRogueWizard",
 				"abbreviation": "UAFRW",
 				"full": "Unearthed Arcana: Fighter, Rogue, and Wizard",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-PsychicSoulPsionics.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-11-25",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-PsychicSoulPsionics.pdf",
-				"dateReleased": "2019-11-25"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Fighter.json
+++ b/subclass/Unearthed Arcana - Fighter.json
@@ -5,15 +5,15 @@
 				"json": "UAFighter",
 				"abbreviation": "UAF",
 				"full": "Unearthed Arcana: Fighter",
+				"url": "https://media.wizards.com/2016/dnd/downloads/2016_Fighter_UA_1205_1.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-12-05",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/2016_Fighter_UA_1205_1.pdf",
-				"dateReleased": "2016-12-05"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Giant Soul Sorcerer.json
+++ b/subclass/Unearthed Arcana - Giant Soul Sorcerer.json
@@ -5,15 +5,15 @@
 				"json": "UAGiantSoulSorcerer",
 				"abbreviation": "UAGSS",
 				"full": "Unearthed Arcana: Giant Soul Sorcerer",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_GiantSoul.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-06-11",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_GiantSoul.pdf",
-				"dateReleased": "2018-06-11"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Kits of Old.json
+++ b/subclass/Unearthed Arcana - Kits of Old.json
@@ -5,15 +5,15 @@
 				"json": "UAKitsOfOld",
 				"abbreviation": "UAKoO",
 				"full": "Unearthed Arcana: Kits of Old",
+				"url": "https://media.wizards.com/2015/downloads/dnd/04_UA_Classics_Revisited.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-01-04",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/04_UA_Classics_Revisited.pdf",
-				"dateReleased": "2016-01-04"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Light, Dark, Underdark!.json
+++ b/subclass/Unearthed Arcana - Light, Dark, Underdark!.json
@@ -5,15 +5,15 @@
 				"json": "UALightDarkUnderdark",
 				"abbreviation": "UALDU",
 				"full": "Unearthed Arcana: Light, Dark, Underdark!",
+				"url": "https://media.wizards.com/2015/downloads/dnd/02_UA_Underdark_Characters.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-11-02",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/02_UA_Underdark_Characters.pdf",
-				"dateReleased": "2015-11-02"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Monk.json
+++ b/subclass/Unearthed Arcana - Monk.json
@@ -5,15 +5,15 @@
 				"json": "UAMonk",
 				"abbreviation": "UAMk",
 				"full": "Unearthed Arcana: Monk",
+				"url": "https://media.wizards.com/2016/dnd/downloads/M_2016_UAMonk1_12_12WKWT.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-12-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/M_2016_UAMonk1_12_12WKWT.pdf",
-				"dateReleased": "2016-12-12"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Order Domain.json
+++ b/subclass/Unearthed Arcana - Order Domain.json
@@ -5,15 +5,15 @@
 				"json": "UAOrderDomain",
 				"abbreviation": "UAOD",
 				"full": "Unearthed Arcana: Order Domain",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_OrderDomain.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-04-09",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_OrderDomain.pdf",
-				"dateReleased": "2018-04-09"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "863670f01b"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"subclass": [
 		{

--- a/subclass/Unearthed Arcana - Paladin.json
+++ b/subclass/Unearthed Arcana - Paladin.json
@@ -5,15 +5,15 @@
 				"json": "UAPaladin",
 				"abbreviation": "UAP",
 				"full": "Unearthed Arcana: Paladin",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UAPaladin_SO_20161219_1.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-12-19",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UAPaladin_SO_20161219_1.pdf",
-				"dateReleased": "2016-12-19"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Ranger and Rogue.json
+++ b/subclass/Unearthed Arcana - Ranger and Rogue.json
@@ -5,15 +5,15 @@
 				"json": "UARangerAndRogue",
 				"abbreviation": "UARAR",
 				"full": "Unearthed Arcana: Ranger and Rogue",
+				"url": "https://media.wizards.com/2016/dnd/downloads/2017_01_UA_RangerRogue_0117JCMM.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-01-16",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/2017_01_UA_RangerRogue_0117JCMM.pdf",
-				"dateReleased": "2017-01-16"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Revised Class Options.json
+++ b/subclass/Unearthed Arcana - Revised Class Options.json
@@ -5,15 +5,15 @@
 				"json": "UARevisedClassOptions",
 				"abbreviation": "UARCO",
 				"full": "Unearthed Arcana: Revised Class Options",
+				"url": "https://media.wizards.com/2017/dnd/downloads/June5UA_RevisedClassOptv1.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-06-05",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/June5UA_RevisedClassOptv1.pdf",
-				"dateReleased": "2017-06-05"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Revised Subclasses.json
+++ b/subclass/Unearthed Arcana - Revised Subclasses.json
@@ -5,15 +5,15 @@
 				"json": "UARevisedSubclasses",
 				"abbreviation": "UARSC",
 				"full": "Unearthed Arcana: Revised Subclasses",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA-RevisedSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-05-01",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA-RevisedSubclasses.pdf",
-				"dateReleased": "2017-05-01"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Sorcerer and Warlock.json
+++ b/subclass/Unearthed Arcana - Sorcerer and Warlock.json
@@ -5,15 +5,15 @@
 				"json": "UASorcererAndWarlock",
 				"abbreviation": "UASAW",
 				"full": "Unearthed Arcana: Sorcerer and Warlock",
+				"url": "https://media.wizards.com/2019/dnd/downloads/UA-AberrantLurk.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2019-09-05",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2019/dnd/downloads/UA-AberrantLurk.pdf",
-				"dateReleased": "2019-09-05"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Sorcerer.json
+++ b/subclass/Unearthed Arcana - Sorcerer.json
@@ -5,15 +5,15 @@
 				"json": "UASorcerer",
 				"abbreviation": "UAS",
 				"full": "Unearthed Arcana: Sorcerer",
+				"url": "https://media.wizards.com/2017/dnd/downloads/26_UASorcererUA020617s.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-02-06",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/26_UASorcererUA020617s.pdf",
-				"dateReleased": "2017-02-06"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - The Faithful.json
+++ b/subclass/Unearthed Arcana - The Faithful.json
@@ -5,15 +5,15 @@
 				"json": "UATheFaithful",
 				"abbreviation": "UATF",
 				"full": "Unearthed Arcana: The Faithful",
+				"url": "https://media.wizards.com/2016/dnd/downloads/UA%20Non-Divine%20Faithful%20SFG.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2016-08-01",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2016/dnd/downloads/UA%20Non-Divine%20Faithful%20SFG.pdf",
-				"dateReleased": "2016-08-01"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Three Subclasses.json
+++ b/subclass/Unearthed Arcana - Three Subclasses.json
@@ -5,15 +5,15 @@
 				"json": "UAThreeSubclasses",
 				"abbreviation": "UATSC",
 				"full": "Unearthed Arcana: Three Subclasses",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA-3Subclasses0108.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-01-08",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA-3Subclasses0108.pdf",
-				"dateReleased": "2018-01-08"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Warlock and Wizard.json
+++ b/subclass/Unearthed Arcana - Warlock and Wizard.json
@@ -5,15 +5,15 @@
 				"json": "UAWarlockAndWizard",
 				"abbreviation": "UAWAW",
 				"full": "Unearthed Arcana: Warlock and Wizard",
+				"url": "https://media.wizards.com/2017/dnd/downloads/20170213_Wizrd_Wrlck_UAv2_i48nf.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-02-13",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/20170213_Wizrd_Wrlck_UAv2_i48nf.pdf",
-				"dateReleased": "2017-02-13"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana - Wizard Revisited.json
+++ b/subclass/Unearthed Arcana - Wizard Revisited.json
@@ -5,15 +5,15 @@
 				"json": "UAWizardRevisited",
 				"abbreviation": "UAWR",
 				"full": "Unearthed Arcana: Wizard Revisited",
+				"url": "https://media.wizards.com/2017/dnd/downloads/MJ320UAWizardVF2017.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-03-20",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/MJ320UAWizardVF2017.pdf",
-				"dateReleased": "2017-03-20"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana 2020 - Subclasses Revisited.json
+++ b/subclass/Unearthed Arcana 2020 - Subclasses Revisited.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SubclassesRevisited",
 				"abbreviation": "UA20SCR",
 				"full": "Unearthed Arcana: 2020 Subclasses Revisited",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_SubclassesRevisited_0512.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-05-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_SubclassesRevisited_0512.pdf",
-				"dateReleased": "2020-05-12"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana 2020 - Subclasses, Part 1.json
+++ b/subclass/Unearthed Arcana 2020 - Subclasses, Part 1.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SubclassesPt1",
 				"abbreviation": "UA20S1",
 				"full": "Unearthed Arcana: 2020 Subclasses, Part 1",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020-Subclasses01.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-01-14",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020-Subclasses01.pdf",
-				"dateReleased": "2020-01-14"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana 2020 - Subclasses, Part 2.json
+++ b/subclass/Unearthed Arcana 2020 - Subclasses, Part 2.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SubclassesPt2",
 				"abbreviation": "UA20S2",
 				"full": "Unearthed Arcana: 2020 Subclasses, Part 2",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_02_06_Subclasses2.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-02-04",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_02_06_Subclasses2.pdf",
-				"dateReleased": "2020-02-04"
+				]
 			}
 		],
 		"dependencies": {
@@ -25,6 +25,11 @@
 		"dateAdded": 1701616429,
 		"dateLastModified": 1729637619,
 		"_dateLastModifiedHash": "640a671918"
+	},
+	"_test": {
+		"references": [
+			"UAClassFeatureVariants"
+		]
 	},
 	"subclass": [
 		{

--- a/subclass/Unearthed Arcana 2020 - Subclasses, Part 3.json
+++ b/subclass/Unearthed Arcana 2020 - Subclasses, Part 3.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SubclassesPt3",
 				"abbreviation": "UA20S3",
 				"full": "Unearthed Arcana: 2020 Subclasses, Part 3",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020-Subclasses03_0224.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-02-24",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020-Subclasses03_0224.pdf",
-				"dateReleased": "2020-02-24"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana 2020 - Subclasses, Part 4.json
+++ b/subclass/Unearthed Arcana 2020 - Subclasses, Part 4.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SubclassesPt4",
 				"abbreviation": "UA20S4",
 				"full": "Unearthed Arcana: 2020 Subclasses, Part 4",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_Subclasses04.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-08-05",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_Subclasses04.pdf",
-				"dateReleased": "2020-08-05"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana 2020 - Subclasses, Part 5.json
+++ b/subclass/Unearthed Arcana 2020 - Subclasses, Part 5.json
@@ -5,15 +5,15 @@
 				"json": "UA2020SubclassesPt5",
 				"abbreviation": "UA20S5",
 				"full": "Unearthed Arcana: 2020 Subclasses, Part 5",
+				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_102620_Subclasses05.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2020-10-26",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2020/dnd/downloads/UA2020_102620_Subclasses05.pdf",
-				"dateReleased": "2020-10-26"
+				]
 			}
 		],
 		"edition": "classic",

--- a/subclass/Unearthed Arcana 2021 - Mages of Strixhaven.json
+++ b/subclass/Unearthed Arcana 2021 - Mages of Strixhaven.json
@@ -5,15 +5,15 @@
 				"json": "UA2021MagesOfStrixhaven",
 				"abbreviation": "UA21MoS",
 				"full": "Unearthed Arcana: 2021 Mages of Strixhaven",
+				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_06_08_MagesStrixhaven.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2021-06-08",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2021/dnd/downloads/UA2021_06_08_MagesStrixhaven.pdf",
-				"dateReleased": "2021-06-08"
+				]
 			}
 		],
 		"internalCopies": [

--- a/subclass/Unearthed Arcana 2025 - Apocalyptic Subclasses.json
+++ b/subclass/Unearthed Arcana 2025 - Apocalyptic Subclasses.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025ApocalypticSubclasses",
 				"abbreviation": "XUA25ApS",
 				"full": "Unearthed Arcana 2025: Apocalyptic Subclasses",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/apocalyptic-subclasses/KKvJvHGmsJiNaafX/UA2025-ApocalypticSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-08-21",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/apocalyptic-subclasses/KKvJvHGmsJiNaafX/UA2025-ApocalypticSubclasses.pdf",
-				"dateReleased": "2025-08-21"
+				]
 			}
 		],
 		"edition": "one",

--- a/subclass/Unearthed Arcana 2025 - Arcane Subclasses.json
+++ b/subclass/Unearthed Arcana 2025 - Arcane Subclasses.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025ArcaneSubclasses",
 				"abbreviation": "XUA25ArS",
 				"full": "Unearthed Arcana 2025: Arcane Subclasses",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/arcane-subclasses/zepvK7DBkeSt6dqv/UA2025-ArcaneSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-06-26",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/arcane-subclasses/zepvK7DBkeSt6dqv/UA2025-ArcaneSubclasses.pdf",
-				"dateReleased": "2025-06-26"
+				]
 			}
 		],
 		"optionalFeatureTypes": {
@@ -25,6 +25,12 @@
 		"dateAdded": 1750964106,
 		"dateLastModified": 1759515868,
 		"_dateLastModifiedHash": "6c64a90d82"
+	},
+	"_test": {
+		"references": [
+			"XUA2025HorrorSubclasses",
+			"XUA2025ArcaneUpdates"
+		]
 	},
 	"subclass": [
 		{

--- a/subclass/Unearthed Arcana 2025 - Arcane Updates.json
+++ b/subclass/Unearthed Arcana 2025 - Arcane Updates.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025ArcaneUpdates",
 				"abbreviation": "XUA25ArU",
 				"full": "Unearthed Arcana 2025: Arcane Updates",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/arcane-subclasses-update/LEwFmioFBYHWqzpd/UA2025-ArcaneSubclassesUpdate.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-09-18",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/arcane-subclasses-update/LEwFmioFBYHWqzpd/UA2025-ArcaneSubclassesUpdate.pdf",
-				"dateReleased": "2025-09-18"
+				]
 			}
 		],
 		"dependencies": {
@@ -22,6 +22,9 @@
 				"XUA2025ArcaneSubclasses"
 			],
 			"subclass": [
+				"XUA2025ArcaneSubclasses"
+			],
+			"optionalfeature": [
 				"XUA2025ArcaneSubclasses"
 			]
 		},
@@ -33,6 +36,11 @@
 		"dateAdded": 1758306933,
 		"dateLastModified": 1758306933,
 		"_dateLastModifiedHash": "5155fddc61"
+	},
+	"_test": {
+		"references": [
+			"XUA2025ArcaneSubclasses"
+		]
 	},
 	"subclass": [
 		{
@@ -1317,7 +1325,7 @@
 			"level": 14,
 			"header": 3,
 			"entries": [
-				"When an Undead creature you can see is reduced to 0 {@variantrule Hit Points|XPHB}, you can cause it to explode with necrotic energy. Roll a number of {@dice d6|d6s} equal to half the creature's unexpended {@variantrule Hit Dice|XPHB} (round up, minimum of {@dice 1d6}) and add them together. Each creature in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the Undead makes a Dexterity saving throw. On a failed save, a target takes Necrotic damage equal to the number rolled and can't take {@variantrule Reaction|XPHB|Reactions} until the start of its next turn. On a successful save, a target takes half as much damage only. When you use this feature to explode an Undead creature you don't control, you must take a {@variantrule Reaction|XPHB} and expend a level 5+ spell slot to do so."
+				"When an Undead creature you can see is reduced to 0 {@variantrule Hit Points|XPHB}, you can cause it to explode with necrotic energy. Roll a number of {@dice d6|d6s} equal to half the creature's unexpended {@variantrule Hit Point Dice|XPHB|Hit Dice} (round up, minimum of {@dice 1d6}) and add them together. Each creature in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the Undead makes a Dexterity saving throw. On a failed save, a target takes Necrotic damage equal to the number rolled and can't take {@variantrule Reaction|XPHB|Reactions} until the start of its next turn. On a successful save, a target takes half as much damage only. When you use this feature to explode an Undead creature you don't control, you must take a {@variantrule Reaction|XPHB} and expend a level 5+ spell slot to do so."
 			]
 		},
 		{
@@ -1435,7 +1443,7 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"When you cast a Transmutation spell that doesn't deal damage, such as {@spell Fly|XPHB} or {@spell Magical Weapon|XPHB}, using a spell slot, you can treat the spell as if it were cast using a spell slot 1 level above the slot expended.",
+				"When you cast a Transmutation spell that doesn't deal damage, such as {@spell Fly|XPHB} or {@spell Magic Weapon|XPHB|Magical Weapon}, using a spell slot, you can treat the spell as if it were cast using a spell slot 1 level above the slot expended.",
 				"You can use this feature a number of times equal to your Intelligence modifier (minimum of once), and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
 			]
 		},
@@ -2583,7 +2591,7 @@
 															"name": "Necromancy Spellbook",
 															"nameDot": false,
 															"entries": [
-																"now lets you use the {@spell Find Familiar|XPHB} spell to summon a {@creature Skeleton|XMM} or {@creature Zombie|XMM}, and {@subclassFeature Grim Harvest|Wizard|XPHB|Necromancer|XUA2025ArcaneUpdates|3|XUA2025ArcaneUpdates} now restores {@variantrule Hit Points|XPHB} to an Undead creature of your choice."
+																"now lets you use the {@spell Find Familiar|XPHB} spell to summon a {@creature Skeleton|XMM} or {@creature Zombie|XMM}, and {@subclassFeature Necromancy Spellbook|Wizard|XPHB|Necromancer|XUA2025ArcaneUpdates|3|XUA2025ArcaneUpdates|Grim Harvest} now restores {@variantrule Hit Points|XPHB} to an Undead creature of your choice."
 															]
 														},
 														{

--- a/subclass/Unearthed Arcana 2025 - Forgotten Realms Subclasses.json
+++ b/subclass/Unearthed Arcana 2025 - Forgotten Realms Subclasses.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025ForgottenRealmsSubclasses",
 				"abbreviation": "XUA25FRS",
 				"full": "Unearthed Arcana 2025: Forgotten Realms Subclasses",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/forgotten-realms-subclasses/OXcW3UjTCurUcQy7/UA2025-RealmsSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-01-28",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/forgotten-realms-subclasses/OXcW3UjTCurUcQy7/UA2025-RealmsSubclasses.pdf",
-				"dateReleased": "2025-01-28"
+				]
 			}
 		],
 		"edition": "one",

--- a/subclass/Unearthed Arcana 2025 - Horror Subclasses.json
+++ b/subclass/Unearthed Arcana 2025 - Horror Subclasses.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025HorrorSubclasses",
 				"abbreviation": "XUA25HS",
 				"full": "Unearthed Arcana 2025: Horror Subclasses",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/horror-subclasses/gPZTjw31gGeVdQKl/UA2025-HorrorSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-05-06",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/horror-subclasses/gPZTjw31gGeVdQKl/UA2025-HorrorSubclasses.pdf",
-				"dateReleased": "2025-05-06"
+				]
 			}
 		],
 		"dependencies": {
@@ -27,6 +27,11 @@
 		"dateAdded": 1746541631,
 		"dateLastModified": 1755811150,
 		"_dateLastModifiedHash": "6d8ba1eb9f"
+	},
+	"_test": {
+		"references": [
+			"XUA2025EberronUpdates"
+		]
 	},
 	"subclass": [
 		{
@@ -2660,7 +2665,7 @@
 							"name": "What's Inside",
 							"page": 1,
 							"entries": [
-								"This document presents eight subclasses: revised subclasses for the {@class Bard|XPHB} ({@class Bard|XPHB|College of Spirits|Spirits|XUA2025HorrorSubclasses}), {@class Cleric|XPHB} ({@class Cleric|XPHB|Grave Domain|Grave|XUA2025HorrorSubclasses}), {@class Rogue|XPHB} ({@class Rogue|XPHB|Phantom|Phantom|XUA2025HorrorSubclasses}), {@class Sorcerer|XPHB} ({@class Sorcerer|XPHB|Shadow Sorcery|Shadow|XUA2025HorrorSubclasses}), and {@class Warlock|XPHB} ({@class Warlock|XPHB|Hexblade Patron|Hexblade|XUA2025HorrorSubclasses} and {@class Warlock|XPHB|Undead Patron|Undead|XUA2025HorrorSubclasses}) as well as new subclasses for the {@class Artificer|XPHB} ({@class Artificer|XPHB|Reanimator|Reanimator|XUA2025HorrorSubclasses}) and {@class Ranger|XPHB} ({@class Ranger|XPHB|Hollow Warden|Hollow Warden|XUA2025HorrorSubclasses}).",
+								"This document presents eight subclasses: revised subclasses for the {@class Bard|XPHB} ({@class Bard|XPHB|College of Spirits|Spirits|XUA2025HorrorSubclasses}), {@class Cleric|XPHB} ({@class Cleric|XPHB|Grave Domain|Grave|XUA2025HorrorSubclasses}), {@class Rogue|XPHB} ({@class Rogue|XPHB|Phantom|Phantom|XUA2025HorrorSubclasses}), {@class Sorcerer|XPHB} ({@class Sorcerer|XPHB|Shadow Sorcery|Shadow|XUA2025HorrorSubclasses}), and {@class Warlock|XPHB} ({@class Warlock|XPHB|Hexblade Patron|Hexblade|XUA2025HorrorSubclasses} and {@class Warlock|XPHB|Undead Patron|Undead|XUA2025HorrorSubclasses}) as well as new subclasses for the {@class Artificer|XUA2025EberronUpdates} ({@class Artificer|XUA2025EberronUpdates|Reanimator|Reanimator|XUA2025HorrorSubclasses}) and {@class Ranger|XPHB} ({@class Ranger|XPHB|Hollow Warden|Hollow Warden|XUA2025HorrorSubclasses}).",
 								{
 									"type": "inset",
 									"name": "This Is Playtest Material",
@@ -2705,7 +2710,7 @@
 							"name": "Subclasses",
 							"page": 1,
 							"entries": [
-								"This section presents the following subclasses: the {@class Artificer|XPHB|Reanimator|Reanimator|XUA2025HorrorSubclasses}, {@class Bard|XPHB|College of Spirits|Spirits|XUA2025HorrorSubclasses}, {@class Cleric|XPHB|Grave Domain|Grave|XUA2025HorrorSubclasses}, {@class Ranger|XPHB|Hollow Warden|Hollow Warden|XUA2025HorrorSubclasses}, {@class Rogue|XPHB|Phantom|Phantom|XUA2025HorrorSubclasses}, {@class Sorcerer|XPHB|Shadow Sorcery|Shadow|XUA2025HorrorSubclasses}, {@class Warlock|XPHB|Hexblade Patron|Hexblade|XUA2025HorrorSubclasses}, and {@class Warlock|XPHB|Undead Patron|Undead|XUA2025HorrorSubclasses}.",
+								"This section presents the following subclasses: the {@class Artificer|XUA2025EberronUpdates|Reanimator|Reanimator|XUA2025HorrorSubclasses}, {@class Bard|XPHB|College of Spirits|Spirits|XUA2025HorrorSubclasses}, {@class Cleric|XPHB|Grave Domain|Grave|XUA2025HorrorSubclasses}, {@class Ranger|XPHB|Hollow Warden|Hollow Warden|XUA2025HorrorSubclasses}, {@class Rogue|XPHB|Phantom|Phantom|XUA2025HorrorSubclasses}, {@class Sorcerer|XPHB|Shadow Sorcery|Shadow|XUA2025HorrorSubclasses}, {@class Warlock|XPHB|Hexblade Patron|Hexblade|XUA2025HorrorSubclasses}, and {@class Warlock|XPHB|Undead Patron|Undead|XUA2025HorrorSubclasses}.",
 								{
 									"type": "entries",
 									"name": "Artificer: Reanimator",

--- a/subclass/Unearthed Arcana 2025 - Subclasses Update.json
+++ b/subclass/Unearthed Arcana 2025 - Subclasses Update.json
@@ -6,15 +6,15 @@
 				"json": "XUA2025SubclassesUpdate",
 				"abbreviation": "XUA25SU",
 				"full": "Unearthed Arcana 2025: Subclasses Update",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/subclasses-update/PWtmnmBuM6NVYAXE/UA2025+Updated+Subclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2025-10-30",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/subclasses-update/PWtmnmBuM6NVYAXE/UA2025+Updated+Subclasses.pdf",
-				"dateReleased": "2025-10-30"
+				]
 			}
 		],
 		"edition": "one",

--- a/subclass/Unearthed Arcana 2026 - Mystic Subclasses.json
+++ b/subclass/Unearthed Arcana 2026 - Mystic Subclasses.json
@@ -6,15 +6,15 @@
 				"json": "XUA2026MysticSubclasses",
 				"abbreviation": "XUA26MS",
 				"full": "Unearthed Arcana 2026: Mystic Subclasses",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/mystic-subclasses/mrF6k4xf0yYFJL2m/UA2026-MysticSubclasses.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2026-01-15",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Lyra [he/him]"
-				],
-				"version": "1.0.0",
-				"url": "https://media.dndbeyond.com/compendium-images/ua/mystic-subclasses/mrF6k4xf0yYFJL2m/UA2026-MysticSubclasses.pdf",
-				"dateReleased": "2026-01-15"
+				]
 			}
 		],
 		"edition": "one",
@@ -1038,7 +1038,7 @@
 			"level": 3,
 			"header": 2,
 			"entries": [
-				"Immediately after a creature you can see within 30 feet of you casts a level 1+ spell, you can take a {@variantrule Reaction|XPHB} to absorb magical energy from the spell. When you do so, until the end of your next turn, the next time you hit with your {@classFeature Sneak Attack|Rogue|XPHB|1|PHB} you deal extra Force damage. To determine the extra damage, roll a number of {@dice d6|d6s} equal to the spell's level, and add them together.",
+				"Immediately after a creature you can see within 30 feet of you casts a level 1+ spell, you can take a {@variantrule Reaction|XPHB} to absorb magical energy from the spell. When you do so, until the end of your next turn, the next time you hit with your {@classFeature Sneak Attack|Rogue|XPHB|1|XPHB} you deal extra Force damage. To determine the extra damage, roll a number of {@dice d6|d6s} equal to the spell's level, and add them together.",
 				"You can take this {@variantrule Reaction|XPHB} a number of times equal to your Intelligence modifier (minimum of once), and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
 			]
 		},
@@ -1222,7 +1222,7 @@
 			"level": 3,
 			"header": 2,
 			"entries": [
-				"The magic of your {@creature Vestige Companion|XPHB} ensures you always have certain spells ready. Select one of the following {@class Cleric} Domains: {@subclassFeature Life Domain Spells|Cleric|XPHB|Life|XPHB|3|XPHB|Life}, {@subclassFeature Light Domain Spells|Cleric|XPHB|Light|XPHB|3|XPHB|Light}, {@subclassFeature Trickery Domain Spells|Cleric|XPHB|Trickery|XPHB|3|XPHB|Trickery}, or {@subclassFeature War Domain Spells|Cleric|XPHB|War|XPHB|3|XPHB|War}. The Domain Spells of your chosen Domain are Warlock spells for you. When you reach a Warlock level equal to a Cleric Level listed on the Domain Spells table for the Domain you have chosen, you thereafter always have the listed spells prepared.",
+				"The magic of your {@creature Vestige Companion|XUA2026MysticSubclasses} ensures you always have certain spells ready. Select one of the following {@class Cleric} Domains: {@subclassFeature Life Domain Spells|Cleric|XPHB|Life|XPHB|3|XPHB|Life}, {@subclassFeature Light Domain Spells|Cleric|XPHB|Light|XPHB|3|XPHB|Light}, {@subclassFeature Trickery Domain Spells|Cleric|XPHB|Trickery|XPHB|3|XPHB|Trickery}, or {@subclassFeature War Domain Spells|Cleric|XPHB|War|XPHB|3|XPHB|War}. The Domain Spells of your chosen Domain are Warlock spells for you. When you reach a Warlock level equal to a Cleric Level listed on the Domain Spells table for the Domain you have chosen, you thereafter always have the listed spells prepared.",
 				"For example, if you chose the {@subclassFeature War Domain Spells|Cleric|XPHB|War|XPHB|3|XPHB|War Domain} for this feature, when you reach Warlock level 3, you would have the {@spell Guiding Bolt}, {@spell Magic Weapon}, {@spell Shield of Faith}, and {@spell Spiritual Weapon} spells prepared."
 			]
 		},

--- a/subrace/Unearthed Arcana - Elf Subraces.json
+++ b/subrace/Unearthed Arcana - Elf Subraces.json
@@ -5,15 +5,15 @@
 				"json": "UAElfSubraces",
 				"abbreviation": "UAESR",
 				"full": "Unearthed Arcana: Elf Subraces",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA-ElfSubraces.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-11-13",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA-ElfSubraces.pdf",
-				"dateReleased": "2017-11-13"
+				]
 			}
 		],
 		"edition": "classic",

--- a/variantrule/Unearthed Arcana - Greyhawk Initiative.json
+++ b/variantrule/Unearthed Arcana - Greyhawk Initiative.json
@@ -5,15 +5,15 @@
 				"json": "UAGreyhawkInitiative",
 				"abbreviation": "UAGHI",
 				"full": "Unearthed Arcana: Greyhawk Initiative",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UAGreyhawkInitiative.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-07-10",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UAGreyhawkInitiative.pdf",
-				"dateReleased": "2017-07-10"
+				]
 			}
 		],
 		"edition": "classic",

--- a/variantrule/Unearthed Arcana - Mass Combat.json
+++ b/variantrule/Unearthed Arcana - Mass Combat.json
@@ -5,15 +5,15 @@
 				"json": "UAMassCombat",
 				"abbreviation": "UAMAC",
 				"full": "Unearthed Arcana: Mass Combat",
+				"url": "https://media.wizards.com/2017/dnd/downloads/2017_UAMassCombat_MCUA_v1.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-02-21",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/2017_UAMassCombat_MCUA_v1.pdf",
-				"dateReleased": "2017-02-21"
+				]
 			}
 		],
 		"edition": "classic",

--- a/variantrule/Unearthed Arcana - Three-Pillar Experience.json
+++ b/variantrule/Unearthed Arcana - Three-Pillar Experience.json
@@ -5,15 +5,15 @@
 				"json": "UAThreePillarExperience",
 				"abbreviation": "UA3PE",
 				"full": "Unearthed Arcana: Three-Pillar Experience",
+				"url": "https://media.wizards.com/2017/dnd/downloads/UA-ThreePillarXP.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2017-08-07",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2017/dnd/downloads/UA-ThreePillarXP.pdf",
-				"dateReleased": "2017-08-07"
+				]
 			}
 		],
 		"edition": "classic",

--- a/variantrule/Unearthed Arcana - Variant Rules.json
+++ b/variantrule/Unearthed Arcana - Variant Rules.json
@@ -5,15 +5,15 @@
 				"json": "UAVariantRules",
 				"abbreviation": "UAVR",
 				"full": "Unearthed Arcana: Variant Rules",
+				"url": "https://media.wizards.com/2015/downloads/dnd/UA5_VariantRules.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2015-06-08",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2015/downloads/dnd/UA5_VariantRules.pdf",
-				"dateReleased": "2015-06-08"
+				]
 			}
 		],
 		"edition": "classic",

--- a/vehicle/Unearthed Arcana - Of Ships and the Sea.json
+++ b/vehicle/Unearthed Arcana - Of Ships and the Sea.json
@@ -5,15 +5,15 @@
 				"json": "UAOfShipsAndSea",
 				"abbreviation": "UAOSS",
 				"full": "Unearthed Arcana: Of Ships and the Sea",
+				"url": "https://media.wizards.com/2018/dnd/downloads/UA_ShipsSea.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2018-11-12",
 				"authors": [
 					"Wizards of the Coast"
 				],
 				"convertedBy": [
 					"Giddy"
-				],
-				"version": "1.0.0",
-				"url": "https://media.wizards.com/2018/dnd/downloads/UA_ShipsSea.pdf",
-				"dateReleased": "2018-11-12"
+				]
 			}
 		],
 		"edition": "classic",


### PR DESCRIPTION
Addressed all issues in UA, however not all tests pass.

- Outstanding issues relate primarily to cross-file references to (sub)class(Features).
- Many files have issues for `LinkCheck` and various `EntityFileHandler`s that do not seem to be resolved by inclusion of `_test.references`.
- `reprintedAs` raises cross-file link issues that are not resolved by `_test.references`; it makes no sense for `reprintedAs` to fail a file check for homebrew or UA as entities will always have been reprinted in another file.
- Mages of Strixhaven complains about missing class `Generic|Generic`
