### PR TITLE
Add XUA2026VillainousOptionsUpdate

### DIFF
--- a/collection/Unearthed Arcana 2026 - Villainous Options Update.json
+++ b/collection/Unearthed Arcana 2026 - Villainous Options Update.json
@@ -1,0 +1,1962 @@
+{
+	"$schema": "https://raw.githack.com/TheGiddyLimit/5etools-utils/master/schema/ua/homebrew.json",
+	"_meta": {
+		"sources": [
+			{
+				"json": "XUA2026VillainousOptionsUpdate",
+				"abbreviation": "XUA26VOU",
+				"full": "Unearthed Arcana 2026: Villainous Options Update",
+				"url": "https://media.dndbeyond.com/compendium-images/ua/villainous-options-revisited/Cbzg7luMwkSQRoc0/UA2026-VillainousOptionsRevisited.pdf",
+				"version": "1.0.0",
+				"dateReleased": "2026-06-18",
+				"authors": [
+					"Wizards of the Coast"
+				],
+				"convertedBy": [
+					"Lyra [he/him]"
+				]
+			}
+		],
+		"edition": "one",
+		"status": "ready",
+		"dateAdded": 1781806232,
+		"dateLastModified": 1781806232
+	},
+	"subclass": [
+		{
+			"name": "Circle of the Titan",
+			"shortName": "Titan",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Druid",
+			"classSource": "XPHB",
+			"page": 1,
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"Enlarge/Reduce|XPHB",
+							"Thunderwave|XPHB",
+							"Thaumaturgy|XPHB"
+						],
+						"5": [
+							"Fear|XPHB"
+						],
+						"7": [
+							"Fire Shield|XPHB"
+						],
+						"9": [
+							"Destructive Wave|XPHB"
+						]
+					}
+				}
+			],
+			"subclassSpells": [
+				"Enlarge/Reduce|XPHB",
+				"Thunderwave|XPHB",
+				"Thaumaturgy|XPHB",
+				"Fear|XPHB",
+				"Fire Shield|XPHB",
+				"Destructive Wave|XPHB"
+			],
+			"subclassFeatures": [
+				"Circle of the Titan|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate",
+				"Dire Impact|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|6|XUA2026VillainousOptionsUpdate",
+				"Primal Havoc|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|10|XUA2026VillainousOptionsUpdate",
+				"Monstrous Appetite|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|14|XUA2026VillainousOptionsUpdate"
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Demonic Sorcery",
+			"shortName": "Demonic",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"page": 5,
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"Bane|XPHB",
+							"Dissonant Whispers|XPHB",
+							"Spike Growth|XPHB",
+							"Web|XPHB"
+						],
+						"5": [
+							"Dispel Magic|XPHB",
+							"Bestow Curse|XPHB"
+						],
+						"7": [
+							"Giant Insect|XPHB",
+							"Hallucinatory Terrain|XPHB"
+						],
+						"9": [
+							"Contact Other Plane|XPHB",
+							"Modify Memory|XPHB"
+						],
+						"14": [
+							"Summon Fiend|XPHB"
+						]
+					}
+				}
+			],
+			"subclassSpells": [
+				"Bane|XPHB",
+				"Dissonant Whispers|XPHB",
+				"Spike Growth|XPHB",
+				"Web|XPHB",
+				"Dispel Magic|XPHB",
+				"Bestow Curse|XPHB",
+				"Giant Insect|XPHB",
+				"Hallucinatory Terrain|XPHB",
+				"Contact Other Plane|XPHB",
+				"Modify Memory|XPHB",
+				"Summon Fiend|XPHB"
+			],
+			"subclassFeatures": [
+				"Demonic Sorcery|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate",
+				"Abyssal Realm|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|6|XUA2026VillainousOptionsUpdate",
+				"Abyssal Conduit|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|14|XUA2026VillainousOptionsUpdate",
+				"Abyssal Explosion|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|18|XUA2026VillainousOptionsUpdate"
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Hell Knight",
+			"shortName": "Hell Knight",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"page": 4,
+			"subclassFeatures": [
+				"Hell Knight|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate",
+				"Advanced Wounds|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|7|XUA2026VillainousOptionsUpdate",
+				"Infernal Equipment|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|7|XUA2026VillainousOptionsUpdate",
+				"Hellfire Surge|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|10|XUA2026VillainousOptionsUpdate",
+				"Devil's Misfortune|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|15|XUA2026VillainousOptionsUpdate",
+				"Infernal Bargain|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|18|XUA2026VillainousOptionsUpdate"
+			],
+			"hasFluff": true
+		}
+	],
+	"subclassFluff": [
+		{
+			"name": "Circle of the Titan",
+			"shortName": "Titan",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Druid",
+			"classSource": "XPHB",
+			"entries": [
+				"{@i Wreak Colossal Havoc}"
+			]
+		},
+		{
+			"name": "Demonic Sorcery",
+			"shortName": "Demonic",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"entries": [
+				"{@i Summon the Powers of the Abyss}"
+			]
+		},
+		{
+			"name": "Hell Knight",
+			"shortName": "Hell Knight",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"entries": [
+				"{@i Inflict Hellish Wounds and Damn Enemies}"
+			]
+		}
+	],
+	"subclassFeature": [
+		{
+			"name": "Circle of the Titan",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 1,
+			"className": "Druid",
+			"classSource": "XPHB",
+			"subclassShortName": "Titan",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"When civilization violates the natural world\u2014by deforesting ancient groves, polluting sacred waters, or hunting wildlife to the brink of extinction\u2014Druids of the Circle of the Titan intervene. Druids of this order believe that for nature to thrive, society must sometimes fall. To this end, they assume towering, monstrous forms to mete out cataclysmic retribution and forcibly restore the natural order.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle of the Titan Spells|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Titan Form|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				}
+			]
+		},
+		{
+			"name": "Circle of the Titan Spells",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 1,
+			"className": "Druid",
+			"classSource": "XPHB",
+			"subclassShortName": "Titan",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"When you reach a Druid level specified in the {@table Circle of the Titan Spells|XUA2026VillainousOptionsUpdate} table, you thereafter always have the listed spells prepared.",
+				"In addition, you can cast the spells from this feature while you're in your {@subclassFeature Titan Form|Druid|XPHB|Titan|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate}.",
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Circle of the Titan Spells",
+					"page": 1
+				}
+			]
+		},
+		{
+			"name": "Titan Form",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 1,
+			"className": "Druid",
+			"classSource": "XPHB",
+			"subclassShortName": "Titan",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"When you use {@classFeature Wild Shape|Druid|XPHB|2|XPHB}, you can adopt a Titan Form, choosing from the  {@creature Behemoth|XUA2026VillainousOptionsUpdate}, {@creature Leviathan|XUA2026VillainousOptionsUpdate}, and {@creature Insectoid|XUA2026VillainousOptionsUpdate} stat blocks presented later in this subclass's description. You can stay in a Titan Form for 10 minutes, instead of a number of hours.",
+				"Each Titan Form gains additional benefits when you reach the specified Druid Levels, as noted in its respective stat block. Features that apply to your Beast forms also apply to your Titan Form.",
+				"You determine what your Titan Form looks like. Roll on or choose from the {@table Titan Appearance|XUA2026VillainousOptionsUpdate} table to inspire aspects of your form's appearance.",
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Titan Appearance",
+					"page": 2
+				},
+				{
+					"type": "statblock",
+					"tag": "creature",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Behemoth",
+					"page": 2,
+					"collapsed": true
+				},
+				{
+					"type": "statblock",
+					"tag": "creature",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Leviathan",
+					"page": 3,
+					"collapsed": true
+				},
+				{
+					"type": "statblock",
+					"tag": "creature",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Insectoid",
+					"page": 3,
+					"collapsed": true
+				}
+			]
+		},
+		{
+			"name": "Dire Impact",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 2,
+			"className": "Druid",
+			"classSource": "XPHB",
+			"subclassShortName": "Titan",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your Titan Form brings greater devastation, gaining the following benefits.",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Elemental Rend",
+							"entries": [
+								"Whenever you hit with your Titan Form's Rend attack, you can cause it to deal your choice of Acid, Cold, Fire, Lightning, or Thunder damage rather than its normal damage type."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Shock Wave",
+							"entries": [
+								"Once per turn, immediately after you move at least half your {@variantrule Speed|XPHB}, you can create a shock wave in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from you. Each creature in the {@variantrule Emanation [Area of Effect]|XPHB|Emanation} must succeed on a Constitution saving throw against {@dcYourSpellSave} or have the {@condition Prone} condition."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Primal Havoc",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 2,
+			"className": "Druid",
+			"classSource": "XPHB",
+			"subclassShortName": "Titan",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"The unbridled power of nature surges within you, granting you the following benefits.",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Huge Size",
+							"entries": [
+								"You can choose to become Huge when assuming your Titan Form if you're in a big enough space."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Toughened Hide",
+							"entries": [
+								"Immediately after you assume a Huge or larger Titan Form, you can expend a level 1+ spell slot. For the duration of the form, you gain a bonus to your AC equal to half the expended spell slot's level (round up)."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Above It All",
+							"entries": [
+								"While you are Huge or larger in your Titan Form, {@variantrule Difficult Terrain|XPHB} caused by heavy snow, ice, rubble, or undergrowth doesn't cost you extra movement."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Monstrous Appetite",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 2,
+			"className": "Druid",
+			"classSource": "XPHB",
+			"subclassShortName": "Titan",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Your transformation embodies the vast size and terror of nature's titans. You gain the following benefits.",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Gargantuan Size",
+							"entries": [
+								"You can choose to become Gargantuan when assuming your Titan Form if you're in a big enough space."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Grappling Rend",
+							"entries": [
+								"Once per turn, while you are Huge or larger and hit a creature with your Titan Form's Rend attack, you can give the target the {@condition Grappled} condition (escape DC equals {@dcYourSpellSave}). You can have only one target {@condition grappled} in this way at a time."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Swallow",
+							"entries": [
+								"As a {@variantrule Bonus Action|XPHB} while you are Gargantuan, choose one Large or smaller creature {@condition Grappled} by you. The target makes a Strength saving throw against {@dcYourSpellSave}. On a failure, you swallow the target, and the {@condition Grappled} condition ends on it. A swallowed creature has the {@condition Blinded} and {@condition Restrained} conditions, has {@variantrule Cover|XPHB|Total Cover} against attacks and other effects outside of your stomach, and takes Acid damage at the start of each of your turns. To determine this damage, roll a number of {@damage d12|d12s} equal to your Wisdom modifier.",
+								"The number of creatures you can have swallowed at a time equals your Wisdom modifier (minimum of one creature). You must maintain {@status Concentration} to hold swallowed creatures in your stomach. If you lose {@status Concentration} or leave your Titan Form, you regurgitate all swallowed creatures, each of which falls in a space within 10 feet of you and has the {@condition Prone} condition."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Hell Knight",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 4,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Hell Knights are the champions of archdevils and other high-ranking fiends of the Nine Hells, such as cambions and night hags. Armed with the techniques of the Nine Hells' fiercest warriors, Hell Knights inflict infernal wounds and fight with the tenacity of a devil.",
+				"Devils and other sinister figures employ Hell Knights to enact their will across the multiverse. Some Hell Knights are tasked with punishing creatures that violate infernal contracts or flee their consequences. Others act as interplanar bounty hunters, hastening the journey of wicked souls to the River Styx.",
+				"A Hell Knight's relationship with the Nine Hells is transactional. Archdevils see Hell Knights as an investment, and Hell Knights benefit in turn. The {@table Hell Knight Pursuits|XUA2026VillainousOptionsUpdate} table lists reasons why a Fighter might become a Hell Knight.",
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Hell Knight Pursuits",
+					"page": 4
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Diabolical Gift|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hell-Forged Weapon|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Infernal Wound|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				}
+			]
+		},
+		{
+			"name": "Diabolical Gift",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 4,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"As a soldier for the agents of the Nine Hells, you've been given fiendish powers. You gain the following benefits.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Devil's Sight",
+							"entries": [
+								"You can see normally in {@variantrule Dim Light|XPHB} and {@variantrule Darkness|XPHB}\u2014both magical and nonmagical\u2014within 120 feet of yourself."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Devil's Talents",
+							"entries": [
+								"You know {@language Infernal}, the language of devils. If you already know {@language Infernal}, you learn another language of your choice.",
+								"You also gain proficiency in one of these skills of your choice: {@skill Deception}, {@skill Performance}, or {@skill Sleight of Hand}."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Hell-Forged Weapon",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 4,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"When you take the {@action Attack} action, you can imbue each weapon that you are holding with hellfire, transforming it into a Hell-Forged Weapon. It remains transformed in this way until you use this feature again, you have the {@condition Unconscious} condition, or the weapon is more than 5 feet away from you for 1 minute or more. You can also end this effect early (no action required).",
+				"While you wield a Hell-Forged Weapon, it sheds {@variantrule Dim Light|XPHB} in a 5-foot radius, and whenever you deal damage with the weapon, it can deal your choice of Cold, Fire, or Necrotic damage or its normal damage type (choose when you imbue the weapon with hellfire)."
+			]
+		},
+		{
+			"name": "Infernal Wound",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 4,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"Your {@subclassFeature Hell-Forged Weapon|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate} can inflict infernal wounds.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Infernal Wound Die",
+							"entries": [
+								"You have an Infernal Wound Die, which is a {@dice d6}."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Inflicting Infernal Wounds",
+							"entries": [
+								"When you hit a creature with your {@subclassFeature Hell-Forged Weapon|Fighter|XPHB|Hell Knight|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate}, you can deal extra damage equal to one roll of your Infernal Wound Die. This extra damage is of the same type you chose when you imbued the weapon with hellfire. You also give the target an infernal wound if it doesn't already have one.",
+								"While wounded in this way, the target takes damage of the chosen damage type equal to one roll of your Infernal Wound Die at the start of each of its turns. The wound lasts for 1 minute, until the target regains {@variantrule Hit Points|XPHB}, or until the target or a creature within 5 feet of the target takes an action to stanch the wound.",
+								"You can use this feature a number of times equal to your Constitution modifier (minimum of once). You regain all expended uses when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Advanced Wounds",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 4,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"When you roll your Infernal Wound Die, you can apply one of the following effects. If you roll a 6 on the Infernal Wound Die, the effect you choose has an additional Devil's Luck effect. Once you use this feature, you can't do so again until the start of your next turn.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Purulence of Minauros",
+							"entries": [
+								"Caustic pus erupts from the wound. Each enemy in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the target takes Acid damage equal to your Constitution modifier, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn.",
+								"{@b Devil's Luck:} Each creature that takes Acid damage from this effect has a \u22121 penalty to its AC until the end of your next turn."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Rupture of Cania",
+							"entries": [
+								"The wound ruptures with a spurt of arcane energy. The target takes Force damage equal to your Constitution modifier.",
+								"{@b Devil's Luck:} The target subtracts {@dice 1d6} from the next saving throw it makes before the end of your next turn."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Stygian Gangrene",
+							"entries": [
+								"Infernal rime spreads from the wound. The target takes Cold damage equal to your Constitution modifier, and it can't take Reactions until the start of its next turn.",
+								"{@b Devil's Luck:} The target's {@variantrule Speed|XPHB} is halved until the end of its next turn."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Infernal Equipment",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"Your armor and weapons embody infernal armaments forged in the fires of Avernus, granting you the following benefits.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Infernal Resistance",
+							"entries": [
+								"Whenever you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}, choose a damage type: Cold, Fire, or Necrotic. While wearing Heavy armor or wielding a {@item Shield|XPHB}, you have {@variantrule Resistance|XPHB} to that damage type until you choose a different one with this feature."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Unholy Power",
+							"entries": [
+								"When you roll your Infernal Wound Die, you can treat a roll of 1 as a 6."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Hellfire Surge",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"When you use your {@classFeature Action Surge|Fighter|XPHB|2|XPHB} while holding a Hell-Forged Weapon, you erupt with hellfire in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from you that lasts until the end of your next turn. Whenever a creature suffering an infernal wound starts its turn within the {@variantrule Emanation [Area of Effect]|XPHB|Emanation}, it takes damage equal to two rolls of your Infernal Wound Die instead of one."
+			]
+		},
+		{
+			"name": "Devil's Misfortune",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"When a creature with an infernal wound hits you with an attack roll, you can take a {@variantrule Reaction|XPHB} to roll your Infernal Wound Die and reduce the damage taken by the number rolled. On a roll of 6, roll your Infernal Wound Die again (to a maximum of three rolls total), and reduce the damage taken by the total rolled.",
+				"In addition, if the attack is a {@variantrule Critical Hit|XPHB}, it becomes a normal hit."
+			]
+		},
+		{
+			"name": "Infernal Bargain",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"When you roll a 6 on your Infernal Wound Die three or more times before the start of your next turn, you gain {@variantrule Heroic Inspiration|XPHB}. You can use {@variantrule Heroic Inspiration|XPHB} in the following way.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Infernal Inspiration",
+							"entries": [
+								"If a creature you can see within 120 feet of you rolls a {@dice d20} for a {@variantrule D20 Test|XPHB}, you can expend your {@variantrule Heroic Inspiration|XPHB} to force the target to reroll the {@dice d20}.",
+								"If the number rolled causes the target to succeed on the {@variantrule D20 Test|XPHB}, you regain an expended use of {@classFeature Indomitable|Fighter|XPHB|9|XPHB} or {@classFeature Second Wind|Fighter|XPHB|1|XPHB} (your choice). If the number rolled causes the target to fail the {@variantrule D20 Test|XPHB}, you lose {@variantrule Hit Points|XPHB} equal to {@dice 3d6} plus your {@class Fighter|XPHB} level."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Demonic Sorcery",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Demonic",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"The corruptive magic of demons courses through you, making you a conduit for the infinite layers of the Abyss and their horrors. Your gift might stem from distant demonic ancestry, a fated encounter with a demon that cursed you, or a brush with the dark hunger of the Abyss.",
+				"The Abyss is a plane of wickedness and disorder, and this chaos echoes in your innate magic. Abyssal energy erupts from you, warping your body and surroundings in tandem with your sorcery.",
+				"These Abyssal eruptions manifest in strange and gruesome ways. Roll on or choose from the {@table Abyssal Manifestations|XUA2026VillainousOptionsUpdate} table to inspire how your connection to the Abyss might manifest when you channel your demonic power.",
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Abyssal Manifestations",
+					"page": 5
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Abyssal Rupture|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Demonic Spells|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate"
+				}
+			]
+		},
+		{
+			"name": "Abyssal Rupture",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Demonic",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"When you use {@classFeature Innate Sorcery|Sorcerer|XPHB|1|XPHB}, you create a rupture into the Abyss, which fills a 10-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point you can see within 30 feet of yourself with Abyssal energy. When you activate your {@classFeature Innate Sorcery|Sorcerer|XPHB|1|XPHB} and as a {@variantrule Bonus Action|XPHB} while your {@classFeature Innate Sorcery|Sorcerer|XPHB|1|XPHB} is active, you can choose one of the following options. While the rupture persists, you can move the center of the {@variantrule Sphere [Area of Effect]|XPHB|Sphere} to a point you can see within 30 feet of yourself at the start of each of your turns.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Demonic Lash",
+							"entries": [
+								"Make a melee spell attack against a target within 5 feet of the rupture. On a hit, the target takes {@damage 1d8} Slashing damage, and if it is Large or smaller, you can pull it up to 10 feet toward the center of the {@variantrule Sphere [Area of Effect]|XPHB|Sphere}."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Terrifying Screams",
+							"entries": [
+								"Each creature in the rupture must succeed on a Wisdom saving throw against {@dcYourSpellSave} or take {@damage 1d4} Psychic damage."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Demonic Spells",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 6,
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Demonic",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"When you reach a Sorcerer level specified in the {@table Demonic Spells|XUA2026VillainousOptionsUpdate} table, you thereafter always have the listed spells prepared.",
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "XUA2026VillainousOptionsUpdate",
+					"name": "Demonic Spells",
+					"page": 6
+				}
+			]
+		},
+		{
+			"name": "Abyssal Realm",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 6,
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Demonic",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"When you spend at least 1 Sorcery Point as part of a {@action Magic|XPHB} action or a {@variantrule Bonus Action|XPHB} on your turn, you can pull influence from the Abyss. When you do, you create a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from you, or you fill the {@variantrule Sphere [Area of Effect]|XPHB|Sphere} of your {@subclassFeature Abyssal Rupture|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate} with magic from one of the following layers of the Abyss. If an effect requires a saving throw, the DC equals {@dcYourSpellSave}.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Gaping Maw's Frenzy",
+							"entries": [
+								"Designate a direction that is horizontal to you. Each creature in the area that fails a Charisma saving throw must use as much of its movement as possible to move in that direction at the start of its next turn, taking the safest route."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Maze of Azzatar",
+							"entries": [
+								"Each creature in the area makes an Intelligence saving throw. On a failed save, you gain the benefits of the {@condition Invisible} condition against the target until the start of your next turn."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Slime Pits' Haze",
+							"entries": [
+								"Each creature in the area makes a Constitution saving throw. On a failed save, the target has your choice of the {@condition Charmed} or {@condition Poisoned} condition until the start of your next turn."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Abyssal Conduit",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 6,
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Demonic",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Your Abyssal powers reach their full potential. You gain the following benefits.",
+				{
+					"type": "list",
+					"style": "list-hang-subtrait",
+					"items": [
+						{
+							"type": "item",
+							"name": "Rupture Expansion",
+							"entries": [
+								"The size of your {@subclassFeature Abyssal Rupture|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate} is now a 30-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere}, and the area is {@variantrule Difficult Terrain|XPHB} for your enemies."
+							]
+						},
+						{
+							"type": "item",
+							"name": "Fiendish Servant",
+							"entries": [
+								"You always have the {@spell Summon Fiend|XPHB} spell prepared. When you cast the spell, you can modify it so that it doesn't require {@status Concentration|XPHB}. When you do so, the spell's duration becomes 1 minute for that casting, and you must choose Demon when you summon the Fiend.",
+								"In addition, the Fiend has {@variantrule Advantage|XPHB} on attack rolls while within your {@subclassFeature Abyssal Rupture|Sorcerer|XPHB|Demonic|XUA2026VillainousOptionsUpdate|3|XUA2026VillainousOptionsUpdate}."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Abyssal Explosion",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 6,
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Demonic",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 18,
+			"header": 2,
+			"consumes": {
+				"name": "Sorcery Point",
+				"amount": 7
+			},
+			"entries": [
+				"You unleash the chaos of the Abyss. As a {@action Magic|XPHB} action, you fill a 30-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} with an explosion of Abyssal energy. Each creature in the {@variantrule Sphere [Area of Effect]|XPHB|Sphere} makes a Constitution saving throw against {@dcYourSpellSave}. On a failed save, a creature takes {@damage 8d6} Force damage if it isn't a Fiend, and it has the {@condition Incapacitated|XPHB} condition until the start of your next turn.",
+				"Once you use this feature, you can't do so again until you finish a {@variantrule Long Rest|XPHB}, unless you spend 7 Sorcery Points (no action required) to restore your use of it."
+			]
+		}
+	],
+	"foundrySubclassFeature": [
+		{
+			"name": "Diabolical Gift",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"className": "Fighter",
+			"classSource": "XPHB",
+			"subclassShortName": "Hell Knight",
+			"subclassSource": "XUA2026VillainousOptionsUpdate",
+			"level": 3,
+			"effects": [
+				{
+					"transfer": true,
+					"changes": [
+						{
+							"key": "system.attributes.senses.darkvision",
+							"mode": "UPGRADE",
+							"value": 120
+						},
+						{
+							"key": "system.attributes.senses.special",
+							"mode": "ADD",
+							"value": "Devil's Sight"
+						}
+					]
+				}
+			],
+			"entryData": {
+				"languageProficiencies": [
+					{
+						"infernal": true
+					},
+					{
+						"any": 1
+					}
+				],
+				"skillProficiencies": [
+					{
+						"choose": {
+							"from": [
+								"deception",
+								"performance",
+								"sleight of hand"
+							],
+							"count": 1
+						}
+					}
+				]
+			}
+		}
+	],
+	"feat": [
+		{
+			"name": "Atoner's Grace",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "O",
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Disarming Mien",
+					"entries": [
+						"A creature's {@variantrule Hostile [Attitude]|XPHB|Hostile} attitude doesn't impose {@variantrule Disadvantage|XPHB} on your Charisma ({@skill Persuasion|XPHB}) checks to influence that creature."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Parley",
+					"entries": [
+						"When you take the {@action Disengage|XPHB} or {@action Influence|XPHB} action, each creature of your choice within 5 feet of you has {@variantrule Advantage|XPHB} on the next ability check or saving throw it makes before the start of your next turn."
+					]
+				}
+			]
+		},
+		{
+			"name": "Boon of the Bandit King",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "EB",
+			"prerequisite": [
+				{
+					"level": 19
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"max": 30
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Dastardly Charm",
+					"entries": [
+						"You have {@variantrule Advantage|XPHB} on Dexterity ({@skill Sleight of Hand|XPHB}) checks to pick a pocket. When you succeed on such a check, you can cause the target of your theft to willingly part with the item and have the {@condition Charmed|XPHB} condition for 1 minute or until it takes damage. Once you use this benefit, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Uncatchable",
+					"entries": [
+						"You don't provoke {@action Opportunity Attack|XPHB|Opportunity Attacks} when you move out of a creature's reach."
+					]
+				}
+			]
+		},
+		{
+			"name": "Boon of the Cleansed Heart",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "EB",
+			"prerequisite": [
+				{
+					"level": 19
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"max": 30
+				}
+			],
+			"immune": [
+				"necrotic"
+			],
+			"additionalSpells": [
+				{
+					"innate": {
+						"_": {
+							"_": [
+								"Dispel Evil and Good|XPHB"
+							]
+						}
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Cleanse Heart",
+					"entries": [
+						"You can cast {@spell Dispel Evil and Good|XPHB} without expending a spell slot. You can't use the spell's Dismissal special function when you cast it in this way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Radiant Reflection",
+					"entries": [
+						"You have {@variantrule Immunity|XPHB} to Necrotic damage. When you would be subjected to Necrotic damage and don't have the {@condition Incapacitated|XPHB} condition, you can deal {@damage 2d8} Radiant damage to each creature of your choice within a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from yourself."
+					]
+				}
+			]
+		},
+		{
+			"name": "Boon of the Hunter's Eye",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "EB",
+			"prerequisite": [
+				{
+					"level": 19
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"max": 30
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Quick Capture",
+					"entries": [
+						"When you deal damage to a creature you intend to knock out rather than kill, if the target has 20 or fewer {@variantrule Hit Points|XPHB} after your damage is dealt, the target is reduced to 0 {@variantrule Hit Points|XPHB} instead."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Studied Hunter",
+					"entries": [
+						"When you roll {@variantrule Initiative|XPHB}, you can choose a creature you can see; you know whether that creature has any {@variantrule Immunity|XPHB|Immunities}, {@variantrule Resistance|XPHB|Resistances}, or {@variantrule Vulnerability|XPHB|Vulnerabilities}, and if the creature has any, you know what they are."
+					]
+				}
+			]
+		},
+		{
+			"name": "Boon of Unwavering Devotion",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 8,
+			"category": "EB",
+			"prerequisite": [
+				{
+					"level": 19
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"max": 30
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Possession Immunity",
+					"entries": [
+						"You automatically succeed on saving throws to avoid or end possession."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "See Through Illusions",
+					"entries": [
+						"Visual illusions appear transparent to you, and you automatically succeed on saving throws against them."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Undeniable Confidence",
+					"entries": [
+						"Immediately after a creature you can see succeeds on a Wisdom saving throw against an effect you created, you can take a {@variantrule Reaction|XPHB} to force that creature to reroll the save, and it must use the new roll. Once you use this benefit, you can't use it again until you roll {@variantrule Initiative|XPHB} or finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Raised by Cultists",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "O",
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Bloody Revelation",
+					"entries": [
+						"When you become {@status Bloodied|XPHB}, you can take a {@variantrule Reaction|XPHB} to gain {@variantrule Heroic Inspiration|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Communal Caster",
+					"entries": [
+						"When an ally within 5 feet of you makes a Constitution saving throw to maintain {@status Concentration|XPHB}, you can take a {@variantrule Reaction|XPHB} to give your ally {@variantrule Advantage|XPHB} on the save."
+					]
+				}
+			]
+		},
+		{
+			"name": "Trapper",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "O",
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Eye for Detail",
+					"entries": [
+						"You have {@variantrule Advantage|XPHB} on any Intelligence ({@skill Investigation|XPHB}) check you make as part of the {@action Study|XPHB} action."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Swift Tracker",
+					"entries": [
+						"You don't have {@variantrule Disadvantage|XPHB} on Wisdom ({@skill Perception|XPHB} or {@skill Survival|XPHB}) checks while traveling at a {@table Travel Pace|XPHB|Fast pace}, and you have {@variantrule Advantage|XPHB} on such checks while traveling at a {@table Travel Pace|XPHB|Normal pace}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Trap Expert",
+					"entries": [
+						"You can take a {@variantrule Bonus Action|XPHB}, instead of a {@action Utilize|XPHB} action, to set a {@item Hunting Trap|XPHB}. When you set a {@item Hunting Trap|XPHB}, you add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to the DC of the saving throw to avoid the trap and the DC of the check to escape it."
+					]
+				}
+			]
+		},
+		{
+			"name": "Underhanded",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 7,
+			"category": "O",
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Elusive",
+					"entries": [
+						"Immediately after you roll {@variantrule Initiative|XPHB}, you can move up to 10 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Fight Dirty",
+					"entries": [
+						"When a creature one size larger than you or smaller makes an {@action Opportunity Attack|XPHB} against you and misses, you can take a {@variantrule Reaction|XPHB} to give that creature the {@condition Prone|XPHB} condition. You must have a free hand to use this {@variantrule Reaction|XPHB}."
+					]
+				}
+			]
+		}
+	],
+	"monster": [
+		{
+			"name": "Behemoth",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 2,
+			"size": [
+				"L",
+				"H",
+				"G"
+			],
+			"sizeNote": "(Huge Requires Druid Level 10+, Gargantuan Requires Druid Level 14+)",
+			"type": "humanoid",
+			"alignment": [
+				{
+					"special": "Your Alignment Doesn't Change"
+				}
+			],
+			"ac": [
+				{
+					"special": "13 + your Wisdom modifier"
+				}
+			],
+			"hp": {
+				"special": "4 times your Druid level Temp HP"
+			},
+			"speed": {
+				"walk": 40,
+				"climb": 40
+			},
+			"str": {
+				"special": "Your Strength and Dexterity scores are equal to your Wisdom score."
+			},
+			"dex": {
+				"special": "Your Strength and Dexterity scores are equal to your Wisdom score."
+			},
+			"con": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"int": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"wis": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"cha": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"languages": [
+				"Your languages don't change."
+			],
+			"pbNote": "Your Proficiency Bonus doesn't change.",
+			"trait": [
+				{
+					"name": "Siege Monster",
+					"entries": [
+						"You deal double damage to objects and structures."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack (Requires Druid Level 5+)",
+					"entries": [
+						"You make two Rend attacks."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 10 ft. {@h}{@damage 1d8} plus your Wisdom modifier Slashing damage. This damage increases by {@damage 1d8} when you reach Druid levels 6 ({@damage 2d8}) and 12 ({@damage 3d8})."
+					]
+				},
+				{
+					"name": "Incandescent Breath",
+					"entries": [
+						"You expend a level 1+ spell slot. {@actSave dex} DC equals {@dcYourSpellSave}, each creature in a 5-foot-wide, 60-foot-long {@variantrule Line [Area of Effect]|XPHB|Line}. {@actSaveFail} {@damage 2d10} Radiant damage per level of the spell slot expended. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Rampager (Requires Druid Level 10+)",
+					"entries": [
+						"You expend a level 1+ spell slot and move up to half your {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}. When you enter the space of an enemy that is at least two sizes smaller than you for the first time on a turn, that creature is subjected to the following effect. {@actSave str} DC equals {@dcYourSpellSave}. {@actSaveFail} The target has the {@condition Prone} condition. If the target already has the {@condition Prone} condition, it instead takes {@damage 1d10} Bludgeoning damage per level of the spell slot expended."
+					]
+				}
+			],
+			"tokenHref": {
+				"type": "external",
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/unearthed-arcana-img/main/img/XUA2026VillainousOptionsUpdate/tokens/Behemoth.webp"
+			},
+			"traitTags": [
+				"Siege Monster"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"damageTags": [
+				"B",
+				"R",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"dexterity",
+				"strength"
+			]
+		},
+		{
+			"name": "Insectoid",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 3,
+			"size": [
+				"L",
+				"H",
+				"G"
+			],
+			"sizeNote": "(Huge Requires Druid Level 10+, Gargantuan Requires Druid Level 14+)",
+			"type": "humanoid",
+			"alignment": [
+				{
+					"special": "Your Alignment Doesn't Change"
+				}
+			],
+			"ac": [
+				{
+					"special": "13 + your Wisdom Modifier"
+				}
+			],
+			"hp": {
+				"special": "4 times your Druid level Temp HP"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": {
+					"number": 40,
+					"condition": "(requires Druid Level 10+)"
+				}
+			},
+			"str": {
+				"special": "Your Strength and Dexterity scores are equal to your Wisdom score."
+			},
+			"dex": {
+				"special": "Your Strength and Dexterity scores are equal to your Wisdom score."
+			},
+			"con": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"int": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"wis": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"cha": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"languages": [
+				"Your languages don't change."
+			],
+			"pbNote": "Your Proficiency Bonus doesn't change.",
+			"trait": [
+				{
+					"name": "Flyby (Requires Druid Level 10+)",
+					"entries": [
+						"You don't provoke an {@action Opportunity Attack|XPHB} when you fly out of an enemy's reach."
+					]
+				},
+				{
+					"name": "Siege Monster",
+					"entries": [
+						"You deal double damage to objects and structures."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack (Requires Level 5+)",
+					"entries": [
+						"You make two Rend attacks."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 10 ft. {@h}{@damage 1d8} plus your Wisdom modifier Piercing damage. This damage increases by {@damage 1d8} when you reach Druid levels 6 ({@damage 2d8}) and 12 ({@damage 3d8})."
+					]
+				},
+				{
+					"name": "Energizing Pollen",
+					"entries": [
+						"You expend a level 1+ spell slot and can move up to half your {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks} while emitting a cloud of healing pollen. When you move within 5 feet of another creature during this movement, you can restore a number of {@variantrule Hit Points|XPHB} equal to {@dice 2d6} per level of the spell slot expended. A creature can receive this healing only once per turn."
+					]
+				}
+			],
+			"tokenHref": {
+				"type": "external",
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/unearthed-arcana-img/main/img/XUA2026VillainousOptionsUpdate/tokens/Insectoid.webp"
+			},
+			"traitTags": [
+				"Flyby",
+				"Siege Monster"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			]
+		},
+		{
+			"name": "Leviathan",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 3,
+			"size": [
+				"L",
+				"H",
+				"G"
+			],
+			"sizeNote": "(Huge Requires Druid Level 10+, Gargantuan Requires Druid Level 14+)",
+			"type": "humanoid",
+			"alignment": [
+				{
+					"special": "Your Alignment Doesn't Change"
+				}
+			],
+			"ac": [
+				{
+					"special": "13 + your Wisdom Modifier"
+				}
+			],
+			"hp": {
+				"special": "4 times your Druid level Temp HP"
+			},
+			"speed": {
+				"walk": 40,
+				"swim": 40
+			},
+			"str": {
+				"special": "Your Strength and Dexterity scores are equal to your Wisdom score."
+			},
+			"dex": {
+				"special": "Your Strength and Dexterity scores are equal to your Wisdom score."
+			},
+			"con": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"int": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"wis": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"cha": {
+				"special": "Your Constitution, Intelligence, Wisdom, and Charisma don't change."
+			},
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"languages": [
+				"Your languages don't change."
+			],
+			"pbNote": "Your Proficiency Bonus doesn't change.",
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"You can breathe air and water."
+					]
+				},
+				{
+					"name": "Siege Monster",
+					"entries": [
+						"You deal double damage to objects and structures."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack (Requires Druid Level 5+)",
+					"entries": [
+						"You make two Rend attacks."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 10 ft. {@h}{@damage 1d8} plus your Wisdom modifier Bludgeoning damage. This damage increases by {@damage 1d8} when you reach Druid levels 6 ({@damage 2d8}) and 12 ({@damage 3d8})."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Toxic Deluge (Requires Druid Level 10+)",
+					"entries": [
+						"You expend a level 1+ spell slot and emit a toxic miasma. {@actSave con} DC equals {@dcYourSpellSave}, each creature of your choice in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from yourself. {@actSaveFail} {@damage 2d4} Poison damage per level of the spell slot expended, and the target has the {@condition Poisoned|XPHB} condition until the start of your next turn."
+					]
+				}
+			],
+			"tokenHref": {
+				"type": "external",
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/unearthed-arcana-img/main/img/XUA2026VillainousOptionsUpdate/tokens/Leviathan.webp"
+			},
+			"traitTags": [
+				"Amphibious",
+				"Siege Monster"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"damageTags": [
+				"B",
+				"I"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			]
+		}
+	],
+	"table": [
+		{
+			"name": "Abyssal Manifestations",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 5,
+			"colLabels": [
+				"1d6",
+				"Manifestation"
+			],
+			"colStyles": [
+				"col-2 text-center",
+				"col-10"
+			],
+			"rows": [
+				[
+					"1",
+					"Abyssal fissures mar your flesh, revealing windows into a vast demonic realm."
+				],
+				[
+					"2",
+					"Insects writhe beneath your skin and escape from your mouth, nose, and ears."
+				],
+				[
+					"3",
+					"Sheets of scorched skin peel from your body."
+				],
+				[
+					"4",
+					"Your flesh bubbles and froths like a toxic bog."
+				],
+				[
+					"5",
+					"Your fingers or other extremities discolor as if frostbitten."
+				],
+				[
+					"6",
+					"You grow a second head. (This has no impact on your game statistics.)"
+				]
+			]
+		},
+		{
+			"name": "Circle of the Titan Spells",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 1,
+			"colLabels": [
+				"Druid Level",
+				"Prepared Spells"
+			],
+			"colStyles": [
+				"col-2 text-center",
+				"col-10"
+			],
+			"rows": [
+				[
+					"3",
+					"{@spell Enlarge/Reduce|XPHB}, {@spell Thaumaturgy|XPHB}, {@spell Thunderwave|XPHB}"
+				],
+				[
+					"5",
+					"{@spell Fear|XPHB}"
+				],
+				[
+					"7",
+					"{@spell Fire Shield|XPHB}"
+				],
+				[
+					"9",
+					"{@spell Destructive Wave|XPHB}"
+				]
+			]
+		},
+		{
+			"name": "Demonic Spells",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 6,
+			"colLabels": [
+				"Sorcerer Level",
+				"Prepared Spells"
+			],
+			"colStyles": [
+				"col-2 text-center",
+				"col-10"
+			],
+			"rows": [
+				[
+					"3",
+					"{@spell Bane|XPHB}, {@spell Dissonant Whispers|XPHB}, {@spell Spike Growth|XPHB}, {@spell Web|XPHB}"
+				],
+				[
+					"5",
+					"{@spell Bestow Curse|XPHB}, {@spell Dispel Magic|XPHB}"
+				],
+				[
+					"7",
+					"{@spell Giant Insect|XPHB}, {@spell Hallucinatory Terrain|XPHB}"
+				],
+				[
+					"9",
+					"{@spell Contact Other Plane|XPHB}, {@spell Modify Memory|XPHB}"
+				]
+			]
+		},
+		{
+			"name": "Hell Knight Pursuits",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 4,
+			"colLabels": [
+				"1d6",
+				"You Became a Hell Knight Because You..."
+			],
+			"colStyles": [
+				"col-2 text-center",
+				"col-10"
+			],
+			"rows": [
+				[
+					"1",
+					"Desired treasures only the Nine Hells could grant you."
+				],
+				[
+					"2",
+					"Hungered for power beyond mortal bounds."
+				],
+				[
+					"3",
+					"Made a wager with a devil\u2014and lost."
+				],
+				[
+					"4",
+					"Sacrificed your soul to spare someone else's."
+				],
+				[
+					"5",
+					"Sought vengeance on an adversary who wronged you deeply."
+				],
+				[
+					"6",
+					"Were fooled by fine print in an infernal contract."
+				]
+			]
+		},
+		{
+			"name": "Titan Appearance",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"page": 2,
+			"colLabels": [
+				"1d4",
+				"{@creature Behemoth|XUA2026VillainousOptionsUpdate}",
+				"{@creature Leviathan|XUA2026VillainousOptionsUpdate}",
+				"{@creature Insectoid|XUA2026VillainousOptionsUpdate}"
+			],
+			"colStyles": [
+				"col-3 text-center",
+				"col-3",
+				"col-3",
+				"col-3"
+			],
+			"rows": [
+				[
+					"1",
+					"Reflective scales",
+					"Many-tentacled",
+					"Iridescent wings"
+				],
+				[
+					"2",
+					"Multiple heads",
+					"Translucent and blob-like",
+					"Compound eyes"
+				],
+				[
+					"3",
+					"Reptilian tail",
+					"Lamprey-like mouth",
+					"Chitinous horns"
+				],
+				[
+					"4",
+					"Furry and simian",
+					"Serpentine body",
+					"Bioluminescent exoskeleton"
+				]
+			]
+		}
+	],
+	"book": [
+		{
+			"name": "Unearthed Arcana 2026: Villainous Options Update",
+			"id": "XUA2026VillainousOptionsUpdate",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"group": "prerelease",
+			"cover": {
+				"type": "external",
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/unearthed-arcana-img/main/img/XUA2026VillainousOptionsUpdate/cover.webp"
+			},
+			"published": "2026-06-18",
+			"author": "Wizards of the Coast",
+			"contents": [
+				{
+					"name": "Unearthed Arcana 2026: Villainous Options Update",
+					"headers": [
+						"What's Inside",
+						{
+							"header": "Content Warning",
+							"depth": 1
+						},
+						"Subclasses",
+						{
+							"header": "Circle of the Titan (Druid)",
+							"depth": 1
+						},
+						{
+							"header": "Hell Knight (Fighter)",
+							"depth": 1
+						},
+						{
+							"header": "Demonic Sorcery (Sorcerer)",
+							"depth": 1
+						},
+						"Feats",
+						{
+							"header": "Origin Feats",
+							"depth": 1
+						},
+						{
+							"header": "Epic Boon Feats",
+							"depth": 1
+						}
+					]
+				}
+			]
+		}
+	],
+	"bookData": [
+		{
+			"id": "XUA2026VillainousOptionsUpdate",
+			"source": "XUA2026VillainousOptionsUpdate",
+			"data": [
+				{
+					"type": "section",
+					"name": "Unearthed Arcana 2026: Villainous Options Update",
+					"page": 1,
+					"entries": [
+						"This playtest document is part of a series of {@i Unearthed Arcana} articles that present material designed for upcoming products. The material here uses the rules in the {@book Player's Handbook|XPHB}.",
+						{
+							"type": "section",
+							"name": "What's Inside",
+							"page": 1,
+							"entries": [
+								"This document presents revised versions of these three subclasses, incorporating player feedback from the initial playtest in which they appeared:",
+								{
+									"type": "list",
+									"items": [
+										"{@class Druid} ({@class Druid|XPHB|Circle of the Titan|Titan|XUA2026VillainousOptionsUpdate})",
+										"{@class Fighter} ({@class Fighter|XPHB|Hell Knight|Hell Knight|XUA2026VillainousOptionsUpdate})",
+										"{@class Sorcerer} ({@class Sorcerer|XPHB|Demonic Sorcery|Demonic|XUA2026VillainousOptionsUpdate})"
+									]
+								},
+								"This document also includes Origin feats and Epic Boon feats.",
+								{
+									"type": "entries",
+									"name": "Content Warning",
+									"page": 1,
+									"entries": [
+										"This material contains descriptions of body horror, disease, and insects that some readers might find disturbing."
+									]
+								},
+								{
+									"type": "inset",
+									"name": "This Is Playtest Material",
+									"page": 1,
+									"entries": [
+										"This article is presented for playtesting and feedback. The options here are experimental and in draft form. They aren't officially part of the game. Your feedback will help determine whether we adopt them as official.",
+										{
+											"type": "list",
+											"style": "list-hang-notitle",
+											"page": 1,
+											"items": [
+												{
+													"type": "item",
+													"name": "How to Playtest This UA",
+													"entries": [
+														"We invite you to try out this material in play. To play with this material, you may either incorporate it into your campaign or run one or more special playtest sessions. For such a session, you may create an adventure of your own or use a short adventure from a source like {@adventure Dragon Delves|DrDe-BD}."
+													]
+												},
+												{
+													"type": "item",
+													"name": "Power Level",
+													"entries": [
+														"The character options you read here might be more or less powerful than options in the {@book Player's Handbook|XPHB}. If a design survives playtesting, we adjust its power to the desirable level before publication. This means an option could be more or less powerful in its final form."
+													]
+												},
+												{
+													"type": "item",
+													"name": "Feedback",
+													"entries": [
+														"The best way for you to give us feedback on this material is in the survey we'll release on D&D Beyond. If we make this material official, it will be refined based on your feedback, and then it will appear in a D&D book.",
+														"Providing feedback on this document is one way you can help shape the future of D&D!"
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"type": "section",
+							"name": "Subclasses",
+							"page": 1,
+							"entries": [
+								"This section presents the following subclasses: {@class Druid|XPHB|Circle of the Titan|Titan|XUA2026VillainousOptionsUpdate}, {@class Fighter|XPHB|Hell Knight|Hell Knight|XUA2026VillainousOptionsUpdate}, and {@class Sorcerer|XPHB|Demonic Sorcery|Demonic|XUA2026VillainousOptionsUpdate}.",
+								{
+									"type": "entries",
+									"name": "Circle of the Titan (Druid)",
+									"page": 1,
+									"entries": [
+										"{@i Wreak Colossal Havoc}",
+										{
+											"type": "statblock",
+											"prop": "subclass",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Circle of the Titan",
+											"className": "Druid",
+											"classSource": "XPHB",
+											"page": 1,
+											"shortName": "Titan"
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Hell Knight (Fighter)",
+									"page": 4,
+									"entries": [
+										"{@i Inflict Hellish Wounds and Damn Enemies}",
+										{
+											"type": "statblock",
+											"prop": "subclass",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Hell Knight",
+											"className": "Fighter",
+											"classSource": "XPHB",
+											"page": 4,
+											"shortName": "Hell Knight"
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Demonic Sorcery (Sorcerer)",
+									"page": 5,
+									"entries": [
+										"{@i Summon the Powers of the Abyss}",
+										{
+											"type": "statblock",
+											"prop": "subclass",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Demonic Sorcery",
+											"className": "Sorcerer",
+											"classSource": "XPHB",
+											"page": 5,
+											"shortName": "Demonic"
+										}
+									]
+								}
+							]
+						},
+						{
+							"type": "section",
+							"name": "Feats",
+							"page": 7,
+							"entries": [
+								"This section presents eight new feats.",
+								{
+									"type": "entries",
+									"name": "Origin Feats",
+									"page": 7,
+									"entries": [
+										"These feats are in the Origin category.",
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Atoner's Grace",
+											"page": 7
+										},
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Raised by Cultists",
+											"page": 7
+										},
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Trapper",
+											"page": 7
+										},
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Underhanded",
+											"page": 7
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Epic Boon Feats",
+									"page": 7,
+									"entries": [
+										"These feats are in the Epic Boon category.",
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Boon of the Bandit King",
+											"page": 7
+										},
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Boon of the Cleansed Heart",
+											"page": 7
+										},
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Boon of the Hunter's Eye",
+											"page": 7
+										},
+										{
+											"type": "statblock",
+											"tag": "feat",
+											"source": "XUA2026VillainousOptionsUpdate",
+											"name": "Boon of Unwavering Devotion",
+											"page": 8
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/collection/Unearthed Arcana 2026 - Villainous Options.json
+++ b/collection/Unearthed Arcana 2026 - Villainous Options.json
@@ -31,6 +31,9 @@
 			"className": "Druid",
 			"classSource": "XPHB",
 			"page": 3,
+			"reprintedAs": [
+				"Titan|Druid|XPHB|XUA2026VillainousOptionsUpdates"
+			],
 			"additionalSpells": [
 				{
 					"prepared": {
@@ -61,7 +64,7 @@
 			],
 			"subclassFeatures": [
 				"Circle of the Titan|Druid|XPHB|Titan|XUA2026VillainousOptions|3|XUA2026VillainousOptions",
-				"Dire impact|Druid|XPHB|Titan|XUA2026VillainousOptions|6|XUA2026VillainousOptions",
+				"Dire Impact|Druid|XPHB|Titan|XUA2026VillainousOptions|6|XUA2026VillainousOptions",
 				"Primal Havoc|Druid|XPHB|Titan|XUA2026VillainousOptions|10|XUA2026VillainousOptions",
 				"Monstrous Appetite|Druid|XPHB|Titan|XUA2026VillainousOptions|14|XUA2026VillainousOptions"
 			],
@@ -74,6 +77,9 @@
 			"className": "Sorcerer",
 			"classSource": "XPHB",
 			"page": 7,
+			"reprintedAs": [
+				"Demonic|Sorcerer|XPHB|XUA2026VillainousOptionsUpdates"
+			],
 			"additionalSpells": [
 				{
 					"prepared": {
@@ -135,6 +141,9 @@
 			"className": "Fighter",
 			"classSource": "XPHB",
 			"page": 6,
+			"reprintedAs": [
+				"Hell Knight|Fighter|XPHB|XUA2026VillainousOptionsUpdates"
+			],
 			"subclassFeatures": [
 				"Hell Knight|Fighter|XPHB|Hell Knight|XUA2026VillainousOptions|3|XUA2026VillainousOptions",
 				"Advanced Wounds|Fighter|XPHB|Hell Knight|XUA2026VillainousOptions|7|XUA2026VillainousOptions",
@@ -648,7 +657,7 @@
 			"entries": [
 				"Hell Knights are the champions of archdevils and other high-ranking fiends of the Nine Hells, such as cambions and night hags. Armed with the techniques of the Nine Hells' fiercest warriors, Hell Knights inflict infernal wounds and fight with the tenacity of a devil.",
 				"Devils and other sinister figures employ Hell Knights to enact their will across the multiverse. A Hell Knight might serve as a soldier on the front lines of the Blood War, while another might be tasked with punishing creatures that violate infernal contracts or flee their consequences. Others act as interplanar bounty hunters, hastening the journey of wicked souls to the River Styx.",
-				"A Hell Knight's relationship with the Nine Hells is transactional. Archdevils see Hell Knights as an investment, and Hell Knights benefit in turn. The Hell Knight Pursuits table lists reasons why a Fighter might become a Hell Knight.",
+				"A Hell Knight's relationship with the Nine Hells is transactional. Archdevils see Hell Knights as an investment, and Hell Knights benefit in turn. The {@table Hell Knight Pursuits|XUA2026VillainousOptions} table lists reasons why a Fighter might become a Hell Knight.",
 				{
 					"type": "statblock",
 					"tag": "table",
@@ -899,7 +908,7 @@
 			"entries": [
 				"The corruptive magic of demons courses through you, making you a conduit for the infinite layers of the Abyss and their horrors. Your gift might stem from a distant demonic ancestry, a fated encounter with a demon that cursed you, or a brush with the dark hunger of the Abyss.",
 				"The Abyss is a plane of wickedness and disorder, and this chaos echoes in your innate magic. Abyssal energy erupts from you, warping your body and surroundings in tandem with your sorcery.",
-				"These Abyssal eruptions manifest in strange and gruesome ways. Roll on or choose from the Abyssal Manifestations table to inspire how your connection to the Abyss might manifest when you channel your demonic power.",
+				"These Abyssal eruptions manifest in strange and gruesome ways. Roll on or choose from the {@table Abyssal Manifestations|XUA2026VillainousOptions} table to inspire how your connection to the Abyss might manifest when you channel your demonic power.",
 				{
 					"type": "statblock",
 					"tag": "table",
@@ -1938,6 +1947,9 @@
 			"name": "Behemoth",
 			"source": "XUA2026VillainousOptions",
 			"page": 4,
+			"reprintedAs": [
+				"Behemoth|XUA2026VillainousOptionsUpdate"
+			],
 			"size": [
 				"L",
 				"H",
@@ -2053,6 +2065,9 @@
 			"name": "Insectoid",
 			"source": "XUA2026VillainousOptions",
 			"page": 5,
+			"reprintedAs": [
+				"Insectoid|XUA2026VillainousOptionsUpdate"
+			],
 			"size": [
 				"L",
 				"H",
@@ -2158,6 +2173,9 @@
 			"name": "Leviathan",
 			"source": "XUA2026VillainousOptions",
 			"page": 4,
+			"reprintedAs": [
+				"Leviathan|XUA2026VillainousOptionsUpdate"
+			],
 			"size": [
 				"L",
 				"H",


### PR DESCRIPTION
This PR has an outstanding issue with the statblocks which requires an upstream change. 
<img width="660" height="161" alt="image" src="https://github.com/user-attachments/assets/b16da6c8-5ceb-4401-8089-75f3addc4d2b" />

Currently `type` does not accept null, an empty string, undefined and has no special note handling capability outside 'typically', swarms etc. We need a way to fail to provide a validated creature type and provide a custom note in its place. 
Alignment currently uses:
```json
"alignment": [
	{
		"special": "Your Alignment Doesn't Change"
	}
],
``` 

Once this is in place the statblocks can be changed from `humanoid` to the new custom note method.